### PR TITLE
When solving an equation, iterate until error is below half threshold.

### DIFF
--- a/include/hpp/constraints/impl/hybrid-solver.hh
+++ b/include/hpp/constraints/impl/hybrid-solver.hh
@@ -39,7 +39,7 @@ namespace hpp {
 
       hppDout (info, "squareNorm = " << squaredNorm_);
 
-      while (squaredNorm_ > squaredErrorThreshold_ && errorDecreased &&
+      while (squaredNorm_ > .25 * squaredErrorThreshold_ && errorDecreased &&
 	     iter < maxIterations_) {
 
         // Update the jacobian using the jacobian of the explicit system.


### PR DESCRIPTION
  This commit ensures users that two configurations computed to lie in the same
  leaf of the foliation relative to a numerical constraint are effectively
  considered as such by the manipulation steering method.

  If q1 and q2 and q3 are such that

  ||f(q1) - f (q3) || < eps,
  ||f(q2) - f (q3) || < eps,

  || f(q2) - f (q1)|| may be bigger than eps and therefore considered as not
  lying on the same leaf.