### PR TITLE
Fix methods BlockIndex::add

### DIFF
--- a/src/matrix-view.cc
+++ b/src/matrix-view.cc
@@ -99,12 +99,18 @@ namespace Eigen {
     // Sorted insertion of b into a
     segments_t::iterator _it = std::upper_bound (a.begin(), a.end(), b,
         internal::BlockIndexCompFull ());
+    // if a is empty, make sure _it is equal to a.end ()
+    assert (_it == a.end () || !a.empty ());
     a.insert (_it, b);
   }
 
   void BlockIndex::add (segments_t& a, const segments_t& b)
   {
     // Sorted insertion of b into a, assuming b is sorted.
+    if (a.empty ()) {
+      a = b;
+      return;
+    }
     segments_t::iterator _a = a.begin();
     for (segments_t::const_iterator _b = b.begin(); _b != b.end(); ++_b) {
       _a = std::upper_bound (_a, a.end(), *_b, internal::BlockIndexCompFull ());


### PR DESCRIPTION
  - if a is empty, set a to b witout iterating into b,
  - add an assert.

This pull request fixes a segmentation fault in method
void BlockIndex::add (segments_t& a, const segments_t& b)
when a is empty and b contains 2 segments.