### PR TITLE
Improvments and bug fixes in solvers

### DIFF
--- a/include/hpp/constraints/affine-function.hh
+++ b/include/hpp/constraints/affine-function.hh
@@ -21,7 +21,6 @@
 # include <hpp/constraints/config.hh>
 
 # include <hpp/constraints/differentiable-function.hh>
-# include <hpp/constraints/matrix-view.hh>
 
 namespace hpp {
   namespace constraints {
@@ -39,9 +38,7 @@ namespace hpp {
             const std::string name = "LinearFunction")
           : DifferentiableFunction (J.cols(), J.cols(), LiegroupSpace::Rn
                                     (J.rows()), name),
-          J_ (J), b_ (vector_t::Zero(J.rows())),
-          aIdx_ (0, J_.cols()), JIdx_ (0, J_.cols()), C_JIdx_ (0,0),
-          qshort_ (J.cols())
+          J_ (J), b_ (vector_t::Zero(J.rows()))
         {
           init();
         }
@@ -50,42 +47,21 @@ namespace hpp {
             const std::string name = "LinearFunction")
           : DifferentiableFunction (J.cols(), J.cols(), LiegroupSpace::Rn
                                     (J.rows()), name),
-          J_ (J), b_ (b),
-          aIdx_ (0, J_.cols()), JIdx_ (0, J_.cols()), C_JIdx_ (0,0),
-          qshort_ (J.cols())
-        {
-          init();
-        }
-
-        AffineFunction (const matrixIn_t& J, const vectorIn_t& b,
-            Eigen::RowBlockIndices& argSelection,
-            Eigen::ColBlockIndices& derSelection,
-            Eigen::ColBlockIndices& CderSelection,
-            const std::string name = "AffineFunction") :
-          DifferentiableFunction (J.cols(), J.cols(), LiegroupSpace::Rn
-                                  (J.rows()), name),
-          J_ (J), b_ (b),
-          aIdx_ (argSelection), JIdx_ (derSelection), C_JIdx_ (CderSelection),
-          qshort_ (argSelection.nbIndices())
+          J_ (J), b_ (b)
         {
           init();
         }
 
       private:
         /// User implementation of function evaluation
-        void impl_compute (LiegroupElement& result, vectorIn_t argument) const
+        void impl_compute (LiegroupElement& y, vectorIn_t x) const
         {
-          qshort_ = aIdx_.rview(argument);
-          result.vector ().noalias () = J_ * qshort_;
-          result.vector () += b_;
-          result.check ();
+          y.vector ().noalias() = J_ * x + b_;
         }
 
-        void impl_jacobian (matrixOut_t jacobian,
-            vectorIn_t) const
+        void impl_jacobian (matrixOut_t jacobian, vectorIn_t) const
         {
-          JIdx_  .lview(jacobian) = J_;
-          C_JIdx_.lview(jacobian).setZero();
+          jacobian = J_;
         }
 
         void init ()
@@ -97,12 +73,7 @@ namespace hpp {
 
         const matrix_t J_;
         const vector_t b_;
-        const Eigen::RowBlockIndices aIdx_;
-        const Eigen::ColBlockIndices JIdx_, C_JIdx_;
-        mutable vector_t qshort_;
     }; // class AffineFunction
-
-    typedef boost::shared_ptr<AffineFunction> AffineFunctionPtr_t;
 
     /// Constant function
     /// \f$ f(q) = C \f$
@@ -134,8 +105,6 @@ namespace hpp {
 
         const LiegroupElement c_;
     }; // class ConstantFunction
-
-    typedef boost::shared_ptr<ConstantFunction> ConstantFunctionPtr_t;
 
     /// \}
   } // namespace constraints

--- a/include/hpp/constraints/explicit-solver.hh
+++ b/include/hpp/constraints/explicit-solver.hh
@@ -274,7 +274,8 @@ namespace hpp {
           RowBlockIndices equalityIndices;
           vector_t rightHandSide;
 
-          mutable LiegroupElement value;
+          mutable vector_t qin;
+          mutable LiegroupElement value, expected;
           mutable matrix_t jacobian;
         }; // struct Function
 

--- a/include/hpp/constraints/explicit-solver.hh
+++ b/include/hpp/constraints/explicit-solver.hh
@@ -266,7 +266,9 @@ namespace hpp {
           Function (DifferentiableFunctionPtr_t _f, RowBlockIndices ia,
                     RowBlockIndices oa, ColBlockIndices id, RowBlockIndices od,
                     const ComparisonTypes_t& comp);
+          void setG (const DifferentiableFunctionPtr_t& _g, const DifferentiableFunctionPtr_t& _ginv);
           DifferentiableFunctionPtr_t f;
+          DifferentiableFunctionPtr_t g, ginv;
           RowBlockIndices inArg, outArg;
           ColBlockIndices inDer;
           RowBlockIndices outDer;
@@ -274,9 +276,9 @@ namespace hpp {
           RowBlockIndices equalityIndices;
           vector_t rightHandSide;
 
-          mutable vector_t qin;
+          mutable vector_t qin, qout;
           mutable LiegroupElement value, expected;
-          mutable matrix_t jacobian;
+          mutable matrix_t jacobian, jGinv;
         }; // struct Function
 
         RowBlockIndices inArgs_, freeArgs_;

--- a/include/hpp/constraints/explicit-solver.hh
+++ b/include/hpp/constraints/explicit-solver.hh
@@ -37,9 +37,13 @@ namespace hpp {
     /// The solver works on a given set of variables \f$ X = (x_i) \f$.
     /// It contains a set of functions \f$ f_j \f$ that takes as input a subset of \f$ X \f$ and
     /// outputs values corresponding to another subset of \f$ X \f$.
-    /// The equation are then of the following form:
+    /// The equations are then of the following form:
     /// \f$ X_{output} = f (X_{input}) + rhs \f$ where the addition is the
     /// addition of the \ref outputSpace() of \f$ f \f$.
+    ///
+    /// Eventually, a invertible function \f$ g \f$ (of known inverse \f$ g^{-1} \f$)
+    /// can be specified. The equation then becomes:
+    /// \f$ g(X_{output}) = f (X_{input}) + rhs \f$
     /// 
     /// There can be no cycles in the dependencies. Moreover, a variable cannot
     /// be the output of two different functions.

--- a/include/hpp/constraints/explicit-solver.hh
+++ b/include/hpp/constraints/explicit-solver.hh
@@ -92,6 +92,11 @@ namespace hpp {
             const RowBlockIndices& outDer,
             const ComparisonTypes_t& comp);
 
+        /// Set \f$g\f$  and \f$g^{-1}\f$ functions
+        bool setG (const DifferentiableFunctionPtr_t& f,
+                   const DifferentiableFunctionPtr_t& g,
+                   const DifferentiableFunctionPtr_t& ginv);
+
         /// \warning the two functions must have the same input and output
         /// indices.
         bool replace (const DifferentiableFunctionPtr_t& oldf,

--- a/include/hpp/constraints/impl/hybrid-solver.hh
+++ b/include/hpp/constraints/impl/hybrid-solver.hh
@@ -31,7 +31,7 @@ namespace hpp {
       size_type errorDecreased = 3, iter = 0;
       value_type previousSquaredNorm =
 	std::numeric_limits<value_type>::infinity();
-      value_type initSquaredNorm;
+      value_type initSquaredNorm = 0;
 
       // Fill value and Jacobian
       computeValue<true> (arg);

--- a/include/hpp/constraints/impl/hybrid-solver.hh
+++ b/include/hpp/constraints/impl/hybrid-solver.hh
@@ -43,7 +43,7 @@ namespace hpp {
       vector_t initArg;
       if (errorWasBelowThr) {
         initArg = arg;
-        iter = std::max (maxIterations_,size_type(1)) - 1;
+        iter = std::max (maxIterations_,size_type(2)) - 2;
         initSquaredNorm = squaredNorm_;
       }
 

--- a/include/hpp/constraints/impl/hybrid-solver.hh
+++ b/include/hpp/constraints/impl/hybrid-solver.hh
@@ -24,7 +24,6 @@ namespace hpp {
         vectorOut_t arg,
         LineSearchType lineSearch) const
     {
-      hppDout (info, "before projection: " << arg.transpose ());
       assert (!arg.hasNaN());
 
       resetSaturation();
@@ -34,6 +33,7 @@ namespace hpp {
       size_type errorDecreased = 3, iter = 0;
       value_type previousSquaredNorm =
 	std::numeric_limits<value_type>::infinity();
+      value_type initSquaredNorm;
 
       // Fill value and Jacobian
       computeValue<true> (arg);
@@ -44,13 +44,11 @@ namespace hpp {
       if (errorWasBelowThr) {
         initArg = arg;
         iter = std::max (maxIterations_,size_type(1)) - 1;
-        previousSquaredNorm = squaredNorm_;
+        initSquaredNorm = squaredNorm_;
       }
 
       if (squaredNorm_ > .25 * squaredErrorThreshold_
           && reducedDimension_ == 0) return INFEASIBLE;
-
-      hppDout (info, "squareNorm = " << squaredNorm_);
 
       while (squaredNorm_ > .25 * squaredErrorThreshold_ && errorDecreased &&
 	     iter < maxIterations_) {
@@ -65,7 +63,6 @@ namespace hpp {
 	computeValue<true> (arg);
         computeError ();
 
-	hppDout (info, "squareNorm = " << squaredNorm_);
 	--errorDecreased;
 	if (squaredNorm_ < previousSquaredNorm) errorDecreased = 3;
 	previousSquaredNorm = squaredNorm_;
@@ -74,19 +71,15 @@ namespace hpp {
       }
 
       if (errorWasBelowThr) {
-        if (squaredNorm_ > previousSquaredNorm) {
+        if (squaredNorm_ > initSquaredNorm) {
           arg = initArg;
         }
         return SUCCESS;
       }
 
-      hppDout (info, "number of iterations: " << iter);
-      hppDout (info, "saturation: " << reducedSaturation_);
       if (squaredNorm_ > squaredErrorThreshold_) {
-	hppDout (info, "Projection failed.");
         return (!errorDecreased) ? ERROR_INCREASED : MAX_ITERATION_REACHED;
       }
-      hppDout (info, "After projection: " << arg.transpose ());
       assert (!arg.hasNaN());
       return SUCCESS;
     }

--- a/include/hpp/constraints/impl/hybrid-solver.hh
+++ b/include/hpp/constraints/impl/hybrid-solver.hh
@@ -53,6 +53,7 @@ namespace hpp {
 
         // Update the jacobian using the jacobian of the explicit system.
         updateJacobian(arg);
+        computeSaturation(arg);
 
         computeDescentDirection ();
         lineSearch (*this, arg, dq_);

--- a/include/hpp/constraints/impl/hybrid-solver.hh
+++ b/include/hpp/constraints/impl/hybrid-solver.hh
@@ -26,8 +26,6 @@ namespace hpp {
     {
       assert (!arg.hasNaN());
 
-      resetSaturation();
-
       explicit_.solve(arg);
 
       size_type errorDecreased = 3, iter = 0;

--- a/include/hpp/constraints/impl/iterative-solver.hh
+++ b/include/hpp/constraints/impl/iterative-solver.hh
@@ -112,8 +112,6 @@ namespace hpp {
       hppDout (info, "before projection: " << arg.transpose ());
       assert (!arg.hasNaN());
 
-      resetSaturation();
-
       size_type errorDecreased = 3, iter = 0;
       value_type previousSquaredNorm =
 	std::numeric_limits<value_type>::infinity();

--- a/include/hpp/constraints/impl/iterative-solver.hh
+++ b/include/hpp/constraints/impl/iterative-solver.hh
@@ -79,7 +79,7 @@ namespace hpp {
           const size_type nrows = d.reducedJ.rows();
           if (df.size() < nrows) df.resize(nrows);
           df.head(nrows).noalias() = d.reducedJ * solver.dqSmall_;
-          slope += df.head(nrows).dot(d.error);
+          slope += df.head(nrows).dot(d.activeRowsOfJ.keepRows().rview(d.error).eval());
         }
         return slope;
       }

--- a/include/hpp/constraints/impl/iterative-solver.hh
+++ b/include/hpp/constraints/impl/iterative-solver.hh
@@ -126,6 +126,7 @@ namespace hpp {
       while (squaredNorm_ > squaredErrorThreshold_ && errorDecreased &&
 	     iter < maxIterations_) {
 
+        computeSaturation(arg);
         computeDescentDirection ();
         lineSearch (*this, arg, dq_);
 

--- a/include/hpp/constraints/iterative-solver.hh
+++ b/include/hpp/constraints/iterative-solver.hh
@@ -320,6 +320,7 @@ namespace hpp {
 
         /// Compute the value of each level, and the jacobian if ComputeJac is true.
         template <bool ComputeJac> void computeValue (vectorIn_t arg) const;
+        void computeSaturation (vectorIn_t arg) const;
         void getValue (vectorOut_t v) const;
         void getReducedJacobian (matrixOut_t J) const;
         /// If lastIsOptional() is true, then the last level is ignored.

--- a/include/hpp/constraints/iterative-solver.hh
+++ b/include/hpp/constraints/iterative-solver.hh
@@ -95,10 +95,13 @@ namespace hpp {
         /// It should be robust to cases where from and result points to the
         /// same vector in memory (aliasing)
         typedef boost::function<void (vectorIn_t from, vectorIn_t velocity, vectorOut_t result)> Integration_t;
-        /// This function saturates  velocity during unit time, from argument.
-        /// It should be robust to cases where from and result points to the
-        /// same vector in memory (aliasing)
-        typedef boost::function<bool (vectorOut_t result, ArrayXb& saturation)> Saturation_t;
+        /// This function checks what DoF are saturated.
+        /// For each DoF, saturation is set to
+        /// \li -1 if the lower bound is reached.
+        /// \li  1 if the upper bound is reached.
+        /// \li  0 otherwise
+        /// saturates  velocity during unit time, from argument.
+        typedef boost::function<bool (vectorIn_t result, Eigen::VectorXi& saturation)> Saturation_t;
 
         HierarchicalIterativeSolver (const std::size_t& argSize, const std::size_t derSize);
 
@@ -329,12 +332,9 @@ namespace hpp {
           return dq_;
         }
 
-        void resetSaturation () const;
-
         virtual void integrate(vectorIn_t from, vectorIn_t velocity, vectorOut_t result) const
         {
           integrate_ (from, velocity, result);
-          saturate (result);
         }
 
         /// \}
@@ -399,9 +399,8 @@ namespace hpp {
 
         mutable vector_t dq_, dqSmall_;
         mutable matrix_t projector_, reducedJ_;
+        mutable Eigen::VectorXi saturation_, reducedSaturation_;
         mutable ArrayXb tmpSat_;
-        mutable Eigen::Matrix<bool, Eigen::Dynamic, 1> saturation_;
-        mutable Eigen::ColBlockIndices reducedSaturation_;
         mutable value_type squaredNorm_;
         mutable std::vector<Data> datas_;
         mutable SVD_t svd_;

--- a/include/hpp/constraints/matrix-view.hh
+++ b/include/hpp/constraints/matrix-view.hh
@@ -461,6 +461,26 @@ namespace Eigen {
                                                 BlockIndex::extract (cols (), j, nj));
       }
 
+      /// Extract a set of rows
+      /// \param i, ni start and length of the set of rows
+      /// \return new instance
+      MatrixBlocks <AllRows, AllCols> middleRows
+      (size_type i, size_type ni) const
+      {
+        return MatrixBlocks <AllRows, AllCols> (BlockIndex::extract (rows (), i, ni),
+                                                cols ());
+      }
+
+      /// Extract a set of cols
+      /// \param i, ni start and length of the set of rows
+      /// \return new instance
+      MatrixBlocks <AllRows, AllCols> middleCols
+      (size_type j, size_type nj) const
+      {
+        return MatrixBlocks <AllRows, AllCols> (rows (),
+                                                BlockIndex::extract (cols (), j, nj));
+      }
+
     protected:
       /// Empty constructor
       MatrixBlocksBase () {}
@@ -486,6 +506,25 @@ namespace Eigen {
                           const segments_t& cols) :
         m_nbRows(BlockIndex::cardinal(rows)),
         m_nbCols(BlockIndex::cardinal(cols)), m_rows(rows), m_cols(cols)
+      {
+# ifndef NDEBUG
+        // test that input is sorted
+        segments_t r (rows); BlockIndex::sort (r);
+        assert (r == rows);
+        segments_t c (cols); BlockIndex::sort (c);
+        assert (c == cols);
+#endif
+      }
+
+      /// Constructor by vectors of segments
+      /// \param nb0s number of rows,
+      /// \param nbCols number of columns,
+      /// \param rows set of row indices,
+      /// \param cols set of column indices,
+      /// \warning rows and cols must be sorted
+      MatrixBlocks (const size_type& nbrows, const RowIndices_t& rows,
+                    const size_type& nbCols, const ColIndices_t& cols) :
+        m_nbRows(nbRows), m_nbCols(nbCols), m_rows(rows), m_cols(cols)
       {
 # ifndef NDEBUG
         // test that input is sorted

--- a/include/hpp/constraints/matrix-view.hh
+++ b/include/hpp/constraints/matrix-view.hh
@@ -356,7 +356,6 @@ namespace Eigen {
       /// Smaller matrix composed by concatenation of the blocks
       template <typename MatrixType, int _Rows = MatrixType::RowsAtCompileTime, int _Cols = MatrixType::ColsAtCompileTime> struct View {
         typedef MatrixBlockView<MatrixType, _Rows, _Cols, AllRows, AllCols> type;
-        typedef MatrixBlockView<MatrixType, _Rows, _Cols, AllCols, AllRows> transpose_type;
       }; // struct View
 
       Derived const& derived () const { return static_cast<Derived const&> (*this); }

--- a/include/hpp/constraints/matrix-view.hh
+++ b/include/hpp/constraints/matrix-view.hh
@@ -412,18 +412,18 @@ namespace Eigen {
           return typename View<const MatrixType>::transpose_type (other.derived(), nbCols(), cols(), nbRows(), rows());
       }
 
-      MatrixBlocksRef<AllCols, AllRows> transpose()
+      MatrixBlocksRef<AllCols, AllRows> transpose() const
       {
         return MatrixBlocksRef<AllCols, AllRows> (nbCols(), cols(), nbRows(), rows());
       }
 
-      MatrixBlocksRef<AllRows, true> keepRows()
+      MatrixBlocksRef<AllRows, true> keepRows() const
       {
         assert (!AllRows);
         return MatrixBlocksRef<AllRows, true> (nbRows(), rows());
       }
 
-      MatrixBlocksRef<true, AllCols> keepCols()
+      MatrixBlocksRef<true, AllCols> keepCols() const
       {
         assert (!AllCols);
         return MatrixBlocksRef<true, AllCols> (nbCols(), cols());

--- a/include/hpp/constraints/matrix-view.hh
+++ b/include/hpp/constraints/matrix-view.hh
@@ -375,19 +375,6 @@ namespace Eigen {
           return typename View<MatrixType>::type (o, nbRows(), rows(), nbCols(), cols());
       }
 
-      /// Writable view of the smaller matrix transposed
-      /// \param other matrix to whick block are extracted
-      /// \return writable view of the smaller matrix composed by concatenation
-      ///         of blocks and transposed.
-      template <typename MatrixType>
-      EIGEN_STRONG_INLINE typename View<MatrixType>::transpose_type lviewTranspose(const MatrixBase<MatrixType>& other) const {
-        MatrixType& o = const_cast<MatrixBase<MatrixType>&>(other).derived();
-        if (Derived::OneDimension)
-          return typename View<MatrixType>::transpose_type (o, nbIndices(), indices());
-        else
-          return typename View<MatrixType>::transpose_type (o, nbCols(), cols(), nbRows(), rows());
-      }
-
       /// Non-writable view of the smaller matrix
       /// \param other matrix to whick block are extracted
       /// \return non-writable view of the smaller matrix composed by
@@ -398,18 +385,6 @@ namespace Eigen {
           return typename View<const MatrixType>::type (other.derived(), nbIndices(), indices());
         else
           return typename View<const MatrixType>::type (other.derived(), nbRows(), rows(), nbCols(), cols());
-      }
-
-      /// Non-writable view of the smaller matrix transposed
-      /// \param other matrix to whick block are extracted
-      /// \return non-writable view of the smaller matrix composed by
-      ///         concatenation of blocks and transposed.
-      template <typename MatrixType>
-      EIGEN_STRONG_INLINE typename View<const MatrixType>::transpose_type rviewTranspose(const MatrixBase<MatrixType>& other) const {
-        if (Derived::OneDimension)
-          return typename View<const MatrixType>::transpose_type (other.derived(), nbIndices(), indices());
-        else
-          return typename View<const MatrixType>::transpose_type (other.derived(), nbCols(), cols(), nbRows(), rows());
       }
 
       MatrixBlocksRef<AllCols, AllRows> transpose() const

--- a/src/explicit-solver.cc
+++ b/src/explicit-solver.cc
@@ -274,6 +274,8 @@ namespace hpp {
         f.qin = f.inArg.rview(arg);
         if (f.ginv) f.f->value(f.value, f.qin);
         f.f->jacobian(f.jacobian, f.qin);
+        if (f.equalityIndices.nbIndices() > 0)
+          f.f->outputSpace ()->Jintegrate (f.rightHandSide, f.jacobian);
         if (f.ginv) {
           f.value += f.rightHandSide;
           f.ginv->jacobian(f.jGinv, f.value.vector());

--- a/src/explicit-solver.cc
+++ b/src/explicit-solver.cc
@@ -115,9 +115,14 @@ namespace hpp {
     void ExplicitSolver::Function::setG (const DifferentiableFunctionPtr_t& _g,
                                          const DifferentiableFunctionPtr_t& _ginv)
     {
+      assert ( (!_g && !_ginv) // No function g and ginv
+          || ( _g && _ginv
+            && * f->outputSpace() == *_g->outputSpace()
+            && *_g->outputSpace() == *_ginv->outputSpace())
+          // Functions specified and the output spaces are all the same.
+          );
       g = _g;
       ginv = _ginv;
-      assert (bool(g) == bool(ginv));
       size_type n = (g ? g->outputSpace()->nv() : 0);
       jGinv.resize (n,n);
     }
@@ -212,6 +217,20 @@ namespace hpp {
         computeOrder(i, order, computed);
       assert(order == functions_.size());
       return true;
+    }
+
+    bool ExplicitSolver::setG (const DifferentiableFunctionPtr_t& df,
+        const DifferentiableFunctionPtr_t& g,
+        const DifferentiableFunctionPtr_t& ginv)
+    {
+      for (std::size_t i = 0; i < functions_.size (); ++i) {
+        Function& f = functions_[i];
+        if (f.f == df) {
+          f.setG (g, ginv);
+          return true;
+        }
+      }
+      return false;
     }
 
     bool ExplicitSolver::replace (

--- a/src/explicit-solver.cc
+++ b/src/explicit-solver.cc
@@ -41,7 +41,7 @@ namespace hpp {
 
     Eigen::ColBlockIndices ExplicitSolver::activeParameters () const
     {
-      return inArgs_;
+      return inArgs_.transpose();
     }
 
     const Eigen::ColBlockIndices& ExplicitSolver::activeDerivativeParameters () const

--- a/src/hybrid-solver.cc
+++ b/src/hybrid-solver.cc
@@ -74,7 +74,7 @@ namespace hpp {
         hppDnum (info, "Jacobian of stack " << i << " before update:" << iendl
             << pretty_print(d.reducedJ) << iendl
             << "Jacobian of explicit variable of stack " << i << ":" << iendl
-            << pretty_print(explicit_.outDers().rviewTranspose(d.jacobian).eval()));
+            << pretty_print(explicit_.outDers().transpose().rview(d.jacobian).eval()));
         d.reducedJ.noalias() +=
           Eigen::MatrixBlockView<matrix_t> (d.jacobian,
               d.activeRowsOfJ.m_nbRows,
@@ -106,7 +106,7 @@ namespace hpp {
         bool active;
 
         // Test on the variable left free by the explicit solver.
-        adpF = reduction_.rviewTranspose(fs[i]->activeDerivativeParameters().matrix()).eval().array();
+        adpF = reduction_.transpose().rview(fs[i]->activeDerivativeParameters().matrix()).eval().array();
         active = adpF.any();
         if (!active && explicitIOdep.size() > 0) {
           // Test on the variable constrained by the explicit solver.
@@ -131,12 +131,12 @@ namespace hpp {
 
       svd_.compute (reducedJ_);
 
-      dqSmall_ = reduction_.rviewTranspose(darg);
+      dqSmall_ = reduction_.transpose().rview(darg);
 
       vector_t tmp (getV1(svd_).adjoint() * dqSmall_);
       dqSmall_.noalias() -= getV1(svd_) * tmp;
 
-      reduction_.lviewTranspose(result) = dqSmall_;
+      reduction_.transpose().lview(result) = dqSmall_;
     }
 
     std::ostream& HybridSolver::print (std::ostream& os) const

--- a/src/hybrid-solver.cc
+++ b/src/hybrid-solver.cc
@@ -147,6 +147,7 @@ namespace hpp {
       return os;
     }
 
+    template HybridSolver::Status HybridSolver::impl_solve (vectorOut_t arg, lineSearch::Constant       lineSearch) const;
     template HybridSolver::Status HybridSolver::impl_solve (vectorOut_t arg, lineSearch::Backtracking   lineSearch) const;
     template HybridSolver::Status HybridSolver::impl_solve (vectorOut_t arg, lineSearch::FixedSequence  lineSearch) const;
     template HybridSolver::Status HybridSolver::impl_solve (vectorOut_t arg, lineSearch::ErrorNormBased lineSearch) const;

--- a/src/hybrid-solver.cc
+++ b/src/hybrid-solver.cc
@@ -76,11 +76,8 @@ namespace hpp {
             << "Jacobian of explicit variable of stack " << i << ":" << iendl
             << pretty_print(explicit_.outDers().transpose().rview(d.jacobian).eval()));
         d.reducedJ.noalias() +=
-          Eigen::MatrixBlockView<matrix_t> (d.jacobian,
-              d.activeRowsOfJ.m_nbRows,
-              d.activeRowsOfJ.m_rows,
-              explicit_.outDers().m_nbRows,
-              explicit_.outDers().m_rows).eval()
+          Eigen::MatrixBlocksRef<> (d.activeRowsOfJ.keepRows(), explicit_.outDers())
+          .rview(d.jacobian).eval()
           * Je_;
         hppDnum (info, "Jacobian of stack " << i << " after update:" << iendl
             << pretty_print(d.reducedJ) << unsetpyformat);

--- a/src/iterative-solver.cc
+++ b/src/iterative-solver.cc
@@ -348,6 +348,7 @@ namespace hpp {
         v.segment(row, d.output.vector ().rows()) = d.output.vector ();
         row += d.output.vector ().rows();
       }
+      assert (v.rows() == row);
     }
 
     void HierarchicalIterativeSolver::getReducedJacobian (matrixOut_t J) const
@@ -358,6 +359,7 @@ namespace hpp {
         J.middleRows(row, d.reducedJ.rows()) = d.reducedJ;
         row += d.reducedJ.rows();
       }
+      assert (J.rows() == row);
     }
 
     void HierarchicalIterativeSolver::computeError () const

--- a/src/iterative-solver.cc
+++ b/src/iterative-solver.cc
@@ -194,7 +194,7 @@ namespace hpp {
       typedef Eigen::MatrixBlocks<false, false> BlockIndices;
       BlockIndices::segments_t rows;
       for (std::size_t i = 0; i < fs.size (); ++i) {
-        ArrayXb adp = reduction_.rviewTranspose(fs[i]->activeDerivativeParameters().matrix()).eval();
+        ArrayXb adp = reduction_.transpose().rview(fs[i]->activeDerivativeParameters().matrix()).eval();
         if (adp.any()) // If at least one element of adp is true
           rows.push_back (BlockIndices::segment_t
                           (row, fs[i]->outputDerivativeSize()));
@@ -322,7 +322,7 @@ namespace hpp {
       applySaturate = saturate_ (arg, saturation_);
       if (!applySaturate) return;
 
-      reducedSaturation_ = reduction_.rviewTranspose (saturation_);
+      reducedSaturation_ = reduction_.transpose().rview (saturation_);
       assert (
           (    reducedSaturation_.array() == -1
                || reducedSaturation_.array() ==  0

--- a/src/iterative-solver.cc
+++ b/src/iterative-solver.cc
@@ -480,6 +480,7 @@ namespace hpp {
       return os << decindent;
     }
 
+    template HierarchicalIterativeSolver::Status HierarchicalIterativeSolver::solve (vectorOut_t arg, lineSearch::Constant       lineSearch) const;
     template HierarchicalIterativeSolver::Status HierarchicalIterativeSolver::solve (vectorOut_t arg, lineSearch::Backtracking   lineSearch) const;
     template HierarchicalIterativeSolver::Status HierarchicalIterativeSolver::solve (vectorOut_t arg, lineSearch::FixedSequence  lineSearch) const;
     template HierarchicalIterativeSolver::Status HierarchicalIterativeSolver::solve (vectorOut_t arg, lineSearch::ErrorNormBased lineSearch) const;

--- a/tests/explicit-solver.cc
+++ b/tests/explicit-solver.cc
@@ -463,7 +463,7 @@ BOOST_AUTO_TEST_CASE(locked_joints)
     expectedRow.updateRows<true,true,true>();
     BOOST_CHECK_EQUAL (solver.outDers(), expectedRow);
 
-    expectedCol = RowBlockIndices(BlockIndex::difference (
+    expectedCol = ColBlockIndices(BlockIndex::difference (
           BlockIndex::segment_t(0, solver.derSize()),
           expectedRow.rows()));
     BOOST_CHECK_EQUAL (solver.freeDers(), expectedCol);

--- a/tests/explicit-solver.cc
+++ b/tests/explicit-solver.cc
@@ -33,22 +33,14 @@
 #include <hpp/constraints/generic-transformation.hh>
 #include <hpp/constraints/symbolic-calculus.hh>
 
+#include <../tests/util.hh>
+
 using boost::assign::list_of;
 
 using namespace hpp::constraints;
 using Eigen::RowBlockIndices;
 using Eigen::ColBlockIndices;
 using Eigen::BlockIndex;
-
-// This is an ugly fix to make BOOST_CHECK_EQUAL able to print segments_t
-// when they are not equal.
-namespace std {
-  std::ostream& operator<< (std::ostream& os, BlockIndex::segments_t b)
-  {
-    Eigen::internal::print_indices::run (os, b);
-    return os;
-  }
-}
 
 namespace Eigen {
   namespace internal {

--- a/tests/hybrid-solver.cc
+++ b/tests/hybrid-solver.cc
@@ -36,15 +36,6 @@
 using namespace hpp::constraints;
 using boost::assign::list_of;
 
-// This is an ugly fix to make BOOST_CHECK_EQUAL able to print segments_t
-// when they are not equal.
-namespace std {
-  std::ostream& operator<< (std::ostream& os, BlockIndex::segments_t b)
-  {
-    return os << hpp::pretty_print (b);
-  }
-}
-
 class LockedJoint : public DifferentiableFunction
 {
   public:

--- a/tests/hybrid-solver.cc
+++ b/tests/hybrid-solver.cc
@@ -31,6 +31,8 @@
 #include <hpp/constraints/generic-transformation.hh>
 #include <hpp/pinocchio/liegroup-element.hh>
 
+#include <../tests/util.hh>
+
 using namespace hpp::constraints;
 using boost::assign::list_of;
 
@@ -306,8 +308,8 @@ BOOST_AUTO_TEST_CASE(hybrid_solver)
   HybridSolver solver(device->configSize(), device->numberDof());
   solver.maxIterations(20);
   solver.errorThreshold(1e-3);
-  solver.integration(boost::bind(hpp::pinocchio::integrate<false, se3::LieGroupTpl>, device, _1, _2, _3));
-  solver.saturation(boost::bind(hpp::pinocchio::saturate, device, _1, _2));
+  solver.integration(boost::bind(hpp::pinocchio::integrate<true, se3::LieGroupTpl>, device, _1, _2, _3));
+  solver.saturation(boost::bind(saturate, device, _1, _2));
 
   device->currentConfiguration (q);
   device->computeForwardKinematics ();

--- a/tests/iterative-solver.cc
+++ b/tests/iterative-solver.cc
@@ -27,6 +27,8 @@
 #include <hpp/pinocchio/simple-device.hh>
 #include <hpp/constraints/generic-transformation.hh>
 
+#include <../tests/util.hh>
+
 using namespace hpp::constraints;
 
 BOOST_AUTO_TEST_CASE(one_layer)
@@ -48,8 +50,8 @@ BOOST_AUTO_TEST_CASE(one_layer)
   HierarchicalIterativeSolver solver(device->configSize(), device->numberDof());
   solver.maxIterations(20);
   solver.errorThreshold(1e-3);
-  solver.integration(boost::bind(hpp::pinocchio::integrate<false, se3::LieGroupTpl>, device, _1, _2, _3));
-  solver.saturation(boost::bind(hpp::pinocchio::saturate, device, _1, _2));
+  solver.integration(boost::bind(hpp::pinocchio::integrate<true, se3::LieGroupTpl>, device, _1, _2, _3));
+  solver.saturation(boost::bind(saturate, device, _1, _2));
 
   device->currentConfiguration (q);
   device->computeForwardKinematics ();

--- a/tests/matrix-view.cc
+++ b/tests/matrix-view.cc
@@ -226,7 +226,7 @@ template <typename MatrixBlocks_t> void checkMatrixBlocks
 
   BOOST_CHECK_EQUAL(mb.lview(m).eval(), mb.rview(m).eval());
   BOOST_CHECK_EQUAL(mb.rview(m).eval(),
-      mb.rviewTranspose(m.transpose()).eval().transpose());
+      mb.transpose().rview(m.transpose()).eval().transpose());
 
   MatrixXd res(m);
   res = m;

--- a/tests/matrix-view.cc
+++ b/tests/matrix-view.cc
@@ -222,6 +222,8 @@ BOOST_AUTO_TEST_CASE(block_index)
 template <typename MatrixBlocks_t> void checkMatrixBlocks
 (const MatrixBlocks_t& mb, MatrixXd m)
 {
+  BOOST_TEST_MESSAGE("Current matrix block: " << mb);
+
   BOOST_CHECK_EQUAL(mb.lview(m).eval(), mb.rview(m).eval());
   BOOST_CHECK_EQUAL(mb.rview(m).eval(),
       mb.rviewTranspose(m.transpose()).eval().transpose());
@@ -291,11 +293,14 @@ BOOST_AUTO_TEST_CASE(matrix_block_view)
 
   RowsIndices rows(2,2);
   // rows contains indices 2, 3
-  rows.addRow(6, 4);
-  // rows contains indices 2, 3, 6, 7, 8, 9
 
   // Make a ColsIndices from a RowsIndices
   ColsIndices cols (rows);
+
+  rows.addRow(6, 4);
+  // rows contains indices 2, 3, 6, 7, 8, 9
+  cols.addCol(5, 2);
+  // cols contains indices 2, 3, 5, 6
 
   MatrixBlocks_t blocks (rows.rows(), cols.cols());
 
@@ -313,4 +318,10 @@ BOOST_AUTO_TEST_CASE(matrix_block_view)
   checkMatrixBlocks (rows, m);
   checkMatrixBlocks (cols, m);
   checkMatrixBlocks (blocks, m);
+
+  checkMatrixBlocks (rows.transpose(), m);
+  checkMatrixBlocks (cols.transpose(), m);
+  checkMatrixBlocks (blocks.transpose(), m);
+  checkMatrixBlocks (blocks.keepRows(), m);
+  checkMatrixBlocks (blocks.keepCols(), m);
 }

--- a/tests/matrix-view.cc
+++ b/tests/matrix-view.cc
@@ -295,7 +295,7 @@ BOOST_AUTO_TEST_CASE(matrix_block_view)
   // rows contains indices 2, 3
 
   // Make a ColsIndices from a RowsIndices
-  ColsIndices cols (rows);
+  ColsIndices cols (rows.transpose());
 
   rows.addRow(6, 4);
   // rows contains indices 2, 3, 6, 7, 8, 9

--- a/tests/matrix-view.cc
+++ b/tests/matrix-view.cc
@@ -25,18 +25,10 @@
 
 #include <hpp/constraints/matrix-view.hh>
 
+#include <../tests/util.hh>
+
 using namespace Eigen;
 using boost::assign::list_of;
-
-// This is an ugly fix to make BOOST_CHECK_EQUAL able to print segments_t
-// when they are not equal.
-namespace std {
-  std::ostream& operator<< (std::ostream& os, BlockIndex::segments_t b)
-  {
-    internal::print_indices::run (os, b);
-    return os;
-  }
-}
 
 BOOST_AUTO_TEST_CASE(block_index)
 {

--- a/tests/util.hh
+++ b/tests/util.hh
@@ -21,6 +21,8 @@
 #include <hpp/pinocchio/extra-config-space.hh>
 #include <hpp/pinocchio/joint.hh>
 
+#include <hpp/constraints/fwd.hh>
+
 bool saturate (const hpp::pinocchio::DevicePtr_t& robot,
     hpp::pinocchio::vectorIn_t q,
     Eigen::VectorXi& sat)
@@ -64,6 +66,15 @@ bool saturate (const hpp::pinocchio::DevicePtr_t& robot,
       sat[iv] =  0;
   }
   return ret;
+}
+
+// This is an ugly fix to make BOOST_CHECK_EQUAL able to print segments_t
+// when they are not equal.
+namespace std {
+  std::ostream& operator<< (std::ostream& os, hpp::constraints::BlockIndex::segments_t b)
+  {
+    return os << hpp::pretty_print (b);
+  }
 }
 
 #endif // TEST_UTIL_HH

--- a/tests/util.hh
+++ b/tests/util.hh
@@ -17,6 +17,35 @@
 #ifndef TEST_UTIL_HH
 # define TEST_UTIL_HH
 
+#define EIGEN_VECTOR_IS_APPROX(Va, Vb)                                         \
+  BOOST_CHECK_MESSAGE((Va).isApprox(Vb, test_precision),                       \
+      "check " #Va ".isApprox(" #Vb ") failed "                                \
+      "[\n" << (Va).transpose() << "\n!=\n" << (Vb).transpose() << "\n]")
+
+#define EIGEN_VECTOR_IS_NOT_APPROX(Va, Vb)                                     \
+  BOOST_CHECK_MESSAGE(!Va.isApprox(Vb, test_precision),                        \
+      "check !" #Va ".isApprox(" #Vb ") failed "                               \
+      "[\n" << (Va).transpose() << "\n==\n" << (Vb).transpose() << "\n]")
+
+#define EIGEN_IS_APPROX(matrixA, matrixB)                                      \
+  BOOST_CHECK_MESSAGE(matrixA.isApprox(matrixB, test_precision),               \
+      "check " #matrixA ".isApprox(" #matrixB ") failed "                      \
+      "[\n" << matrixA << "\n!=\n" << matrixB << "\n]")
+
+#define EIGEN_IS_NOT_APPROX(matrixA, matrixB)                                  \
+  BOOST_CHECK_MESSAGE(!matrixA.isApprox(matrixB, test_precision),              \
+      "check !" #matrixA ".isApprox(" #matrixB ") failed "                     \
+      "[\n" << matrixA << "\n==\n" << matrixB << "\n]")
+
+#define SOLVER_CHECK_SOLVE(expr,expected)                                      \
+  {                                                                            \
+    HierarchicalIterativeSolver::Status __status = expr;                       \
+    BOOST_CHECK_MESSAGE(__status == HierarchicalIterativeSolver::expected,     \
+        "check " #expr " == " #expected " failed ["                            \
+        << __status << " != " << HierarchicalIterativeSolver::expected << "]");\
+  }
+
+
 #include <pinocchio/multibody/model.hpp>
 
 #include <hpp/pinocchio/device.hh>
@@ -67,6 +96,29 @@ bool saturate (const hpp::pinocchio::DevicePtr_t& robot,
       ret = true;
     } else
       sat[iv] =  0;
+  }
+  return ret;
+}
+template <int Lower, int Upper>
+void simpleIntegration (hpp::constraints::vectorIn_t from, hpp::constraints::vectorIn_t velocity, hpp::constraints::vectorOut_t result)
+{
+  result = (from + velocity).cwiseMin(Upper).cwiseMax(Lower);
+}
+template <int Lower, int Upper>
+bool simpleSaturation (hpp::constraints::vectorIn_t x, Eigen::VectorXi& sat)
+{
+  bool ret = false;
+  for (hpp::constraints::size_type i = 0; i < x.size(); ++i) {
+    if (x[i] <= Lower) {
+      sat[i] = -1;
+      ret = true;
+    }
+    else if (x[i] >= Upper) {
+      sat[i] =  1;
+      ret = true;
+    } else {
+      sat[i] = 0;
+    }
   }
   return ret;
 }

--- a/tests/util.hh
+++ b/tests/util.hh
@@ -1,0 +1,69 @@
+// Copyright (c) 2017, Joseph Mirabel
+// Authors: Joseph Mirabel (joseph.mirabel@laas.fr)
+//
+// This file is part of hpp-constraints.
+// hpp-constraints is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+//
+// hpp-constraints is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Lesser Public License for more details.  You should have
+// received a copy of the GNU Lesser General Public License along with
+// hpp-constraints. If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef TEST_UTIL_HH
+# define TEST_UTIL_HH
+
+#include <hpp/pinocchio/device.hh>
+#include <hpp/pinocchio/extra-config-space.hh>
+#include <hpp/pinocchio/joint.hh>
+
+bool saturate (const hpp::pinocchio::DevicePtr_t& robot,
+    hpp::pinocchio::vectorIn_t q,
+    Eigen::VectorXi& sat)
+{
+  using hpp::pinocchio::size_type;
+  bool ret = false;
+  const se3::Model& model = robot->model();
+
+  for (std::size_t i = 1; i < model.joints.size(); ++i) {
+    const size_type nq = model.joints[i].nq();
+    const size_type nv = model.joints[i].nv();
+    const size_type idx_q = model.joints[i].idx_q();
+    const size_type idx_v = model.joints[i].idx_v();
+    for (size_type j = 0; j < nq; ++j) {
+      const size_type iq = idx_q + j;
+      const size_type iv = idx_v + std::min(j,nv-1);
+      if        (q[iq] >= model.upperPositionLimit[iq]) {
+        sat[iv] =  1;
+        ret = true;
+      } else if (q[iq] <= model.lowerPositionLimit[iq]) {
+        sat[iv] = -1;
+        ret = true;
+      } else
+        sat[iv] =  0;
+    }
+  }
+
+  const hpp::pinocchio::ExtraConfigSpace& ecs = robot->extraConfigSpace();
+  const size_type& d = ecs.dimension();
+
+  for (size_type k = 0; k < d; ++k) {
+    const size_type iq = model.nq + k;
+    const size_type iv = model.nv + k;
+    if        (q[iq] >= ecs.upper(k)) {
+      sat[iv] =  1;
+      ret = true;
+    } else if (q[iq] <= ecs.lower(k)) {
+      sat[iv] = -1;
+      ret = true;
+    } else
+      sat[iv] =  0;
+  }
+  return ret;
+}
+
+#endif // TEST_UTIL_HH


### PR DESCRIPTION
- ExplicitSolver:
  - use `g(q_{out}) = f(q_{in}) + rhs` instead of `q_{out} = f(q_{in}) + rhs`,
  - (bugfix) use derivative of addition operation.
- IterativeSolver:
  - update computation of saturation,
- MatrixBlock:
  - optimization
