### PR TITLE
Refactoring

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,0 +1,24 @@
+                                                                -*- outline -*-
+* Rename LieGroupTpl -> LieGroupMap,
+* Rename a few classes and make old names deprecated:
+  - ExplicitSolver -> ExplicitConstraintSet,
+  - HierarchicalIterativeSolver -> solver::HierarchicalIterative,
+  - HybridSolver -> solver::BySubstitution.
+* Move and rename some classes from hpp-core:
+  - core::Equation and core::NumericalConstraints -> constraints::Implicit,
+  - core::ExplicitNumericalConstraints -> constraints::Explicit.
+* Refactor ExplicitConstraintSet: rename members and methods to better fit RSS
+  paper notation and pinocchio convention:
+  - argSize -> nq,
+  - derSize -> nv,
+  - freeArgs -> notOutArgs_,
+  - freeDers -> notOutDers_,
+  - viewJacobian -> jacobianNotOutToOut.
+* Constructor and create methods of Explicit take a LiegroupSpace instead of a
+  robot,
+* Modify prototype of BySubstitution::projectVectorOnKernel
+  - vectorIn_t -> ConfigurationIn_t,
+  - vectorOut_t -> ConfigurationOut_t.
+* In class HierarchicalIterative, rename "reduction" -> "free variables".
+
+New in 4.1, 2018-05-13

--- a/include/hpp/constraints/active-set-differentiable-function.hh
+++ b/include/hpp/constraints/active-set-differentiable-function.hh
@@ -24,10 +24,22 @@
 namespace hpp {
   namespace constraints {
 
+    /// Handle bounds on input variables of a differentiable function.
+    ///
+    /// This class is a decorator of class DifferentiableFunction that
+    /// sets to 0 some columns of the Jacobian of the function.
+    ///
+    /// The class is used to handle saturation of input variables of
+    /// the function during numerical resolution of implicit constraints
+    /// built with the function.
     class HPP_CONSTRAINTS_DLLAPI ActiveSetDifferentiableFunction :
       public DifferentiableFunction
     {
       public:
+        /// Constructor
+        /// \param f initial differentiable function,
+        /// \intervals set of intervals of indices corresponding to saturated
+        ///            input variables.
         ActiveSetDifferentiableFunction (const DifferentiableFunctionPtr_t& f,
             segments_t intervals)
           : DifferentiableFunction(
@@ -40,11 +52,13 @@ namespace hpp {
           context (f->context());
         }
 
+        /// Get the original function
         const DifferentiableFunction& function() const
         {
           return *function_;
         }
 
+        /// Get the original function
         const DifferentiableFunctionPtr_t& functionPtr() const
         {
           return function_;

--- a/include/hpp/constraints/explicit-constraint-set.hh
+++ b/include/hpp/constraints/explicit-constraint-set.hh
@@ -155,6 +155,11 @@ namespace hpp {
         bool replace (const DifferentiableFunctionPtr_t& oldf,
                       const DifferentiableFunctionPtr_t& newd);
 
+        /// Constructor
+        ///
+        /// \param argSize dimension of vector space in which the robot
+        ///                configuration space is immersed.
+        /// \param derSize dimension of tangent space to configuration space.
         ExplicitConstraintSet (const std::size_t& argSize, const std::size_t derSize)
           : argSize_ (argSize), derSize_ (derSize)
           ,   inArgs_ (), freeArgs_ ()

--- a/include/hpp/constraints/explicit-constraint-set.hh
+++ b/include/hpp/constraints/explicit-constraint-set.hh
@@ -77,10 +77,18 @@ namespace hpp {
     g(\mathbf{q}_{out}) = f(\mathbf{p}_{in}) + rhs
     \f}
 
-    To add explicit constraints, use methods ExplicitConstraintSet::add. Note
-    that explicit constraints should be compatible.
+    To add explicit constraints, use methods ExplicitConstraintSet::add. If the
+    constraint to add is not compatible with the previous one, this method
+    returns -1.
 
     Method ExplicitConstraintSet::solve solves the explicit constraints.
+
+    The combination of compatible explicit constraints is an explicit
+    constraint. As such this class can be considered as an explicit constraint.
+
+    We will therefore use the following notation
+    \li \f$in\f$ for the set of indices of input variables,
+    \li \f$out\f$ for the set of indices of output variables.
     **/
     class HPP_CONSTRAINTS_DLLAPI ExplicitConstraintSet
     {
@@ -117,7 +125,8 @@ namespace hpp {
         /// \param inDer subset of input indices for the velocity,
         /// \param outDer subset of output indices for the velocity,
         /// \return the index of the function if the function was added,
-        /// -1 otherwise.
+        /// -1 if the input explicit constraint is not compatible with the
+        ///       current set.
         /// \note A function can be added iff it is compatible with the
         ///       previously added functions.
         size_type add (const DifferentiableFunctionPtr_t& f,
@@ -157,22 +166,22 @@ namespace hpp {
 
         /// Constructor
         ///
-        /// \param argSize dimension of vector space in which the robot
+        /// \param nq dimension of vector space in which the robot
         ///                configuration space is immersed.
-        /// \param derSize dimension of tangent space to configuration space.
-        ExplicitConstraintSet (const std::size_t& argSize, const std::size_t derSize)
-          : argSize_ (argSize), derSize_ (derSize)
-          ,   inArgs_ (), freeArgs_ ()
-          ,   inDers_ (), freeDers_ ()
+        /// \param nv dimension of tangent space to configuration space.
+        ExplicitConstraintSet (const std::size_t& nq, const std::size_t nv)
+          : nq_ (nq), nv_ (nv)
+          ,   inArgs_ (), notOutArgs_ ()
+          ,   inDers_ (), notOutDers_ ()
           ,  outArgs_ (),  outDers_ ()
-          , argFunction_ (Eigen::VectorXi::Constant(argSize, -1))
-          , derFunction_ (Eigen::VectorXi::Constant(derSize, -1))
+          , argFunction_ (Eigen::VectorXi::Constant(nq, -1))
+          , derFunction_ (Eigen::VectorXi::Constant(nv, -1))
           , squaredErrorThreshold_ (Eigen::NumTraits<value_type>::epsilon())
-          // , Jg (derSize, derSize)
-          , arg_ (argSize), diff_(derSize), diffSmall_()
+          // , Jg (nv, nv)
+          , arg_ (nq), diff_(nv), diffSmall_()
         {
-          freeArgs_.addRow(0, argSize);
-          freeDers_.addCol(0, derSize);
+          notOutArgs_.addRow(0, nq);
+          notOutDers_.addCol(0, nv);
         }
 
         /// \}
@@ -201,32 +210,50 @@ namespace hpp {
         /// \name Input and outputs
         /// \{
 
-        /// The set of variable indices which affects the output.
-        /// This is a subset of \ref freeArgs
+        /// Set \f$in\f$ of input configuration variables
         const RowBlockIndices& inArgs () const
         {
           return inArgs_;
         }
 
-        /// The set of derivative variable indices which affects the output.
-        /// This is a subset of \ref freeDers
+        /// Set of input velocity variables
         const ColBlockIndices& inDers () const
         {
           return inDers_;
         }
 
-        /// The set of variable indices which are not affected by the
-        /// resolution.
-        const RowBlockIndices& freeArgs () const
+        /// Set \f$i\overline{n\cup ou}t\f$ of other configuration variables
+        ///
+        /// Configuration variables that are neither input nor output
+        /// \deprecated use \ref notOutArgs
+        const RowBlockIndices& freeArgs () const HPP_CONSTRAINTS_DEPRECATED
         {
-          return freeArgs_;
+          return notOutArgs_;
         }
 
-        /// The set of derivative variable indices which are not affected by the
-        /// resolution.
-        const ColBlockIndices& freeDers () const
+        /// Set \f$i\overline{n\cup ou}t\f$ of other velocity variables
+        ///
+        /// Velocity variables that are neither input nor output
+        /// \deprecated use \ref notOutDers
+        const ColBlockIndices& freeDers () const HPP_CONSTRAINTS_DEPRECATED
         {
-          return freeDers_;
+          return notOutDers_;
+        }
+
+        /// Set \f$i\overline{n\cup ou}t\f$ of other configuration variables
+        ///
+        /// Configuration variables that are neither input nor output
+        const RowBlockIndices& notOutArgs () const
+        {
+          return notOutArgs_;
+        }
+
+        /// Set \f$i\overline{n\cup ou}t\f$ of other velocity variables
+        ///
+        /// Velocity variables that are neither input nor output
+        const ColBlockIndices& notOutDers () const
+        {
+          return notOutDers_;
         }
 
         /// Same as \ref inArgs
@@ -253,43 +280,98 @@ namespace hpp {
           return derFunction_;
         }
 
-        /// The set of variable indices which are computed.
+        /// Set \f$out\f$ of output configuration variables
+        /// \return the set of intervals corresponding the the configuration
+        ///         variables that are ouputs of the combination of explicit
+        ///         constraints.
         const RowBlockIndices& outArgs () const
         {
           return outArgs_;
         }
 
-        /// The set of derivative variable indices which are computed.
+        /// Set of output velocity variables
+        /// \return the set of intervals corresponding the the velocity
+        ///         variables that are ouputs of the combination of explicit
+        ///         constraints.
         const RowBlockIndices& outDers () const
         {
           return outDers_;
         }
 
-        /// The number of variables
-        const std::size_t& argSize () const
+        /// The number of configuration variables
+        /// \deprecated use \ref nq instead.
+        const std::size_t& argSize () const HPP_CONSTRAINTS_DEPRECATED
         {
-          return argSize_;
+          return nq_;
         }
 
         /// The number of derivative variables
-        const std::size_t& derSize () const
+        /// \deprecated use \ref nv instead.
+        const std::size_t& derSize () const HPP_CONSTRAINTS_DEPRECATED
         {
-          return derSize_;
+          return nv_;
+        }
+
+        /// The number of variables
+        const std::size_t& nq () const
+        {
+          return nq_;
+        }
+
+        /// The number of derivative variables
+        const std::size_t& nv () const
+        {
+          return nv_;
         }
 
         /// \}
 
+        /// Return Jacobian matrix of output variable wrt not output variables
+        /// \deprecated use \ref JacobianNotOutToOut instead.
         inline MatrixBlockView viewJacobian(matrix_t& jacobian) const
+          HPP_CONSTRAINTS_DEPRECATED
         {
           return MatrixBlockView(jacobian,
               outDers_.nbIndices() , outDers_.indices(),
-              freeDers_.nbIndices(), freeDers_.indices());
+              notOutDers_.nbIndices(), notOutDers_.indices());
         }
 
-        // /// \param jacobian must be of dimensions (derSize - freeDers().nbIndices(), freeDers().nbIndices())
-        /// \param jacobian must be of dimensions (derSize, derSize) but only a subsegment will be used.
-        /// \warning it is assumed solve(arg) has been called before.
-        void jacobian(matrixOut_t jacobian, vectorIn_t arg) const;
+        /// Return Jacobian matrix of output variable wrt not output variables
+        ///
+        /// \retval jacobian Jacobian matrix of the mapping from non output
+        ///         variables to output variables. The columns of this matrix
+        ///         corresponding to variables \f$in\f$ are filled with the
+        ///         Jacobian of \f$f\f$:
+        ///         \f{equation}
+        ///         \frac{\partial f}{\partial \mathbf{q}_{in}}
+        ///         (\mathbf{q}_{in}).
+        ///         \f}
+        ///         The columns corresponding to variables
+        ///         \f$i\overline{n\cup ou}t\f$ are set to 0.
+        inline MatrixBlockView jacobianNotOutToOut (matrix_t& jacobian) const
+        {
+          return MatrixBlockView(jacobian,
+              outDers_.nbIndices() , outDers_.indices(),
+              notOutDers_.nbIndices(), notOutDers_.indices());
+        }
+
+        /** Compute the Jacobian of the explicit constraint resolution
+        
+            \param q input configuration
+            \param jacobian square Jacobian matrix of same size as velocity
+                            i.e. given by \ref nv method.
+        
+            The result is the Jacobian of the explicit constraint set considered
+            as a projector that maps to any \f$\mathbf{p}\in\mathcal{C}\f$,
+            \f$\mathbf{q} = E(\mathbf{p})\f$ defined by
+            \f{eqnarray}
+            \mathbf{q}_{\bar{out}} &=& \mathbf{p}_{out} \\
+            \mathbf{q}_{out} &=& g^{-1} (f (\mathbf{p}_{in}) + rhs)
+            \f}
+        
+            \warning it is assumed solve(q) has been called before.
+        */
+        void jacobian(matrixOut_t jacobian, vectorIn_t q) const;
 
         /// \name Right hand side accessors
         /// \{
@@ -371,10 +453,24 @@ namespace hpp {
         typedef std::vector<bool> Computed_t;
 
         void computeFunction(const std::size_t& i, vectorOut_t arg) const;
+        /// Compute rows of Jacobian corresponding to output of function
+        ///
+        /// \param i index of the explicit constraint,
+        /// \retval J Jacobian in which rows are computed
+        ///
+        /// Let
+        ///   \li E = (f, in, out) be the explicit constraint of index i,
+        ///   \li E.jacobian be the Jacobian of f,
+        ///   \li E.in the input velocity variables of the constraints,
+        ///   \li E.out the output velocity variables of the constraints,
+        ///   \li Jin the matrix composed of E.in rows of J,
+        ///   \li Jout the matrix composed of E.out rows of J,
+        /// then,
+        ///   Jout = E.jacobian * Jin
         void computeJacobian(const std::size_t& i, matrixOut_t J) const;
         void computeOrder(const std::size_t& iF, std::size_t& iOrder, Computed_t& computed);
 
-        const std::size_t argSize_, derSize_;
+        const std::size_t nq_, nv_;
 
         struct Function {
           Function (DifferentiableFunctionPtr_t _f, RowBlockIndices ia,
@@ -395,16 +491,20 @@ namespace hpp {
           mutable matrix_t jacobian, jGinv;
         }; // struct Function
 
-        RowBlockIndices inArgs_, freeArgs_;
-        ColBlockIndices inDers_, freeDers_;
+        RowBlockIndices inArgs_, notOutArgs_;
+        ColBlockIndices inDers_, notOutDers_;
+        /// Output indices
         RowBlockIndices outArgs_, outDers_;
 
         Eigen::MatrixXi inOutDependencies_;
 
         std::vector<Function> functions_;
         std::vector<std::size_t> computationOrder_;
-        /// For dof i, dofFunction_[i] is the index of the function that computes it.
-        /// -1 means it is the output of no function.
+        /// For each configuration variable i, argFunction_[i] is the index in
+        /// functions_ of the function that computes this configuration
+        /// variable.
+        /// -1 means that the configuration variable is not ouput of any
+        /// function in functions_.
         Eigen::VectorXi argFunction_, derFunction_;
         value_type squaredErrorThreshold_;
         // mutable matrix_t Jg;

--- a/include/hpp/constraints/explicit.hh
+++ b/include/hpp/constraints/explicit.hh
@@ -138,6 +138,9 @@ namespace hpp {
       ///            \f$(ov_{1}, \cdots, ov_{n_{ov}})\f$.
       /// \param rhs        right hand side.
       /// \note comparison type for this constraint is always equality
+      /// \deprecated Call method that takes LiegroupSpacePtr_t instead of
+      ///             DevicePtr_t as input and used robot->configSpace () as
+      ///             argument.
       static ExplicitPtr_t create
         (const DevicePtr_t& robot,
          const DifferentiableFunctionPtr_t& function,
@@ -145,7 +148,8 @@ namespace hpp {
 	 const segments_t& inputVelocity,
 	 const segments_t& outputConf,
 	 const segments_t& outputVelocity,
-         const ComparisonTypes_t& comp = ComparisonTypes_t());
+         const ComparisonTypes_t& comp = ComparisonTypes_t())
+        HPP_CONSTRAINTS_DEPRECATED;
 
       /// Create instance and return shared pointer
       ///
@@ -159,8 +163,57 @@ namespace hpp {
       ///            \f$(ov_{1}, \cdots, ov_{n_{ov}})\f$.
       /// \param rhs        right hand side.
       /// \note comparison type for this constraint is always equality
+      /// \deprecated Call method that takes LiegroupSpacePtr_t instead of
+      ///             DevicePtr_t as input and used robot->configSpace () as
+      ///             argument.
       static ExplicitPtr_t create
         (const DevicePtr_t& robot,
+         const DifferentiableFunctionPtr_t& function,
+         const DifferentiableFunctionPtr_t& g,
+         const DifferentiableFunctionPtr_t& ginv,
+	 const segments_t& inputConf,
+	 const segments_t& inputVelocity,
+	 const segments_t& outputConf,
+	 const segments_t& outputVelocity,
+         const ComparisonTypes_t& comp = ComparisonTypes_t())
+        HPP_CONSTRAINTS_DEPRECATED;
+
+      /// Create instance and return shared pointer
+      ///
+      /// \param configSpace Configuration space on which the constraint is
+      ///        defined,
+      /// \param function relation between input configuration variables and
+      ///        output configuration variables,
+      /// \param outputConf set of integer intervals defining indices
+      ///            \f$(oc_{1}, \cdots, oc_{n_{oc}})\f$,
+      /// \param outputVeclocity set of integer defining indices
+      ///            \f$(ov_{1}, \cdots, ov_{n_{ov}})\f$.
+      /// \param rhs        right hand side.
+      /// \note comparison type for this constraint is always equality
+      static ExplicitPtr_t create
+        (const LiegroupSpacePtr_t& configSpace,
+         const DifferentiableFunctionPtr_t& function,
+	 const segments_t& inputConf,
+	 const segments_t& inputVelocity,
+	 const segments_t& outputConf,
+	 const segments_t& outputVelocity,
+         const ComparisonTypes_t& comp = ComparisonTypes_t());
+
+      /// Create instance and return shared pointer
+      ///
+      /// \param configSpace Configuration space on which the constraint is
+      ///        defined,
+      /// \param function relation between input configuration variables and
+      ///        output configuration variables,
+      /// \param g,ginv
+      /// \param outputConf set of integer intervals defining indices
+      ///            \f$(oc_{1}, \cdots, oc_{n_{oc}})\f$,
+      /// \param outputVeclocity set of integer defining indices
+      ///            \f$(ov_{1}, \cdots, ov_{n_{ov}})\f$.
+      /// \param rhs        right hand side.
+      /// \note comparison type for this constraint is always equality
+      static ExplicitPtr_t create
+        (const LiegroupSpacePtr_t& configSpace,
          const DifferentiableFunctionPtr_t& function,
          const DifferentiableFunctionPtr_t& g,
          const DifferentiableFunctionPtr_t& ginv,
@@ -221,13 +274,16 @@ namespace hpp {
       ///            \f$(ov_{1}, \cdots, ov_{n_{ov}})\f$.
       /// \param rhs        right hand side.
       /// \note comparison type for this constraint is always equality
+      /// \deprecated Use constructor that takes LiegroupSpacePtr_t instead of
+      ///             DevicePtr_t as input and used robot->configSpace () as
+      ///             argument.
       Explicit
 	(const DevicePtr_t& robot, const DifferentiableFunctionPtr_t& function,
 	 const segments_t& inputConf,
 	 const segments_t& inputVelocity,
 	 const segments_t& outputConf,
 	 const segments_t& outputVelocity,
-         const ComparisonTypes_t& comp);
+         const ComparisonTypes_t& comp) HPP_CONSTRAINTS_DEPRECATED;
 
       /// Constructor
       ///
@@ -241,8 +297,56 @@ namespace hpp {
       ///            \f$(ov_{1}, \cdots, ov_{n_{ov}})\f$.
       /// \param rhs        right hand side.
       /// \note comparison type for this constraint is always equality
+      /// \deprecated Use constructor that takes LiegroupSpacePtr_t instead of
+      ///             DevicePtr_t as input and used robot->configSpace () as
+      ///             argument.
       Explicit
 	(const DevicePtr_t& robot, const DifferentiableFunctionPtr_t& function,
+         const DifferentiableFunctionPtr_t& g,
+         const DifferentiableFunctionPtr_t& ginv,
+	 const segments_t& inputConf,
+	 const segments_t& inputVelocity,
+	 const segments_t& outputConf,
+	 const segments_t& outputVelocity,
+         const ComparisonTypes_t& comp) HPP_CONSTRAINTS_DEPRECATED;
+
+      /// Constructor
+      ///
+      /// \param configSpace Configuration space on which the constraint is
+      ///        defined,
+      /// \param function relation between input configuration variables and
+      ///        output configuration variables,
+      /// \param outputConf set of integer intervals defining indices
+      ///            \f$(oc_{1}, \cdots, oc_{n_{oc}})\f$,
+      /// \param outputVeclocity set of integer defining indices
+      ///            \f$(ov_{1}, \cdots, ov_{n_{ov}})\f$.
+      /// \param rhs        right hand side.
+      /// \note comparison type for this constraint is always equality
+      Explicit
+	(const LiegroupSpacePtr_t& configSpace,
+         const DifferentiableFunctionPtr_t& function,
+	 const segments_t& inputConf,
+	 const segments_t& inputVelocity,
+	 const segments_t& outputConf,
+	 const segments_t& outputVelocity,
+         const ComparisonTypes_t& comp);
+
+      /// Constructor
+      ///
+      /// \param configSpace Configuration space on which the constraint is
+      ///        defined,
+      /// \param function relation between input configuration variables and
+      ///        output configuration variables,
+      /// \param g, ginv
+      /// \param outputConf set of integer intervals defining indices
+      ///            \f$(oc_{1}, \cdots, oc_{n_{oc}})\f$,
+      /// \param outputVeclocity set of integer defining indices
+      ///            \f$(ov_{1}, \cdots, ov_{n_{ov}})\f$.
+      /// \param rhs        right hand side.
+      /// \note comparison type for this constraint is always equality
+      Explicit
+	(const LiegroupSpacePtr_t& configSpace,
+         const DifferentiableFunctionPtr_t& function,
          const DifferentiableFunctionPtr_t& g,
          const DifferentiableFunctionPtr_t& ginv,
 	 const segments_t& inputConf,

--- a/include/hpp/constraints/explicit/function.hh
+++ b/include/hpp/constraints/explicit/function.hh
@@ -37,14 +37,57 @@ namespace hpp {
     class Function : public DifferentiableFunction
     {
     public:
+      /// create instance and return shared pointer
+      /// \deprecated used create method that takes a LiegroupSpace instead
+      ///             of a robot as input.
       typedef boost::shared_ptr <Function> Ptr_t;
       static Ptr_t create
       (const DevicePtr_t& robot, const DifferentiableFunctionPtr_t& function,
        const segments_t& inputConf, const segments_t& inputVelocity,
-       const segments_t& outputConf, const segments_t& outputVelocity);
+       const segments_t& outputConf, const segments_t& outputVelocity)
+        HPP_CONSTRAINTS_DEPRECATED;
 
+      /// create instance and return shared pointer
+      /// \deprecated used create method that takes a LiegroupSpace instead
+      ///             of a robot as input.
       static Ptr_t create
       (const DevicePtr_t& robot, const DifferentiableFunctionPtr_t& function,
+       const DifferentiableFunctionPtr_t& g,
+       const segments_t& inputConf, const segments_t& inputVelocity,
+       const segments_t& outputConf, const segments_t& outputVelocity)
+        HPP_CONSTRAINTS_DEPRECATED;
+
+      /// create instance and return shared pointer
+      ///
+      /// \param configSpace input space of this function - usually a robot
+      ///                    configuration space,
+      /// \param function function f,
+      /// \param inputConf set of indices defining q_in,
+      /// \param inputVelocity set of indices defining q_in derivative,
+      /// \param outputConf set of indices defining q_out
+      /// \param outputVel set of indices defining q_out derivative
+      ///
+      /// Function g is set to identity.
+
+      static Ptr_t create
+      (const LiegroupSpacePtr_t& configSpace,
+       const DifferentiableFunctionPtr_t& function,
+       const segments_t& inputConf, const segments_t& inputVelocity,
+       const segments_t& outputConf, const segments_t& outputVelocity);
+
+      /// create instance and return shared pointer
+      ///
+      /// \param configSpace input space of this function - usually a robot
+      ///                    configuration space,
+      /// \param function function f,
+      /// \param g function g,
+      /// \param inputConf set of indices defining q_in,
+      /// \param inputVelocity set of indices defining q_in derivative,
+      /// \param outputConf set of indices defining q_out
+      /// \param outputVel set of indices defining q_out derivative
+      static Ptr_t create
+      (const LiegroupSpacePtr_t& configSpace,
+       const DifferentiableFunctionPtr_t& function,
        const DifferentiableFunctionPtr_t& g,
        const segments_t& inputConf, const segments_t& inputVelocity,
        const segments_t& outputConf, const segments_t& outputVelocity);
@@ -53,15 +96,35 @@ namespace hpp {
       const DifferentiableFunctionPtr_t& inputToOutput () const;
 
     protected:
+      /// Constructor
+      /// \deprecated used constructor that takes a LiegroupSpace instead
+      ///             of a robot as input.
       Function (const DevicePtr_t& robot,
 			const DifferentiableFunctionPtr_t& function,
                         const DifferentiableFunctionPtr_t& g,
 			const segments_t& inputConf,
 			const segments_t& inputVelocity,
                         const segments_t& outputConf,
-			const segments_t& outputVelocity);
+			const segments_t& outputVelocity)
+        HPP_CONSTRAINTS_DEPRECATED;
 
-      /// Compute q_{output} - f (q_{input})
+      /// Constructor
+      /// \param configSpace input space of this function - usually a robot
+      ///                    configuration space,
+      /// \param function function f,
+      /// \param g function g,
+      /// \param inputConf set of indices defining q_in,
+      /// \param inputVelocity set of indices defining q_in derivative,
+      /// \param outputConf set of indices defining q_out
+      /// \param outputVel set of indices defining q_out derivative
+      Function (const LiegroupSpacePtr_t& configSpace,
+                const DifferentiableFunctionPtr_t& function,
+                const DifferentiableFunctionPtr_t& g,
+                const segments_t& inputConf,
+                const segments_t& inputVelocity,
+                const segments_t& outputConf,
+                const segments_t& outputVelocity);
+      /// Compute g (q_out) - f (q_in)
       void impl_compute (LiegroupElement& result, vectorIn_t argument) const;
 
       /// Compute Jacobian of q_{output} - f (q_{input})

--- a/include/hpp/constraints/explicit/function.hh
+++ b/include/hpp/constraints/explicit/function.hh
@@ -22,14 +22,14 @@
 namespace hpp {
   namespace constraints {
     namespace explicit_ {
-    /// Function of the form f (q) = q2 - g (q1)
+    /// Function of the form q -> g (q_out) - f (q_in)
     ///
     /// where
-    ///  \li q2 is a vector composed of a subset of configuration variables of
+    ///  \li q_out is a vector composed of configuration variables of
     ///      q,
-    ///  \li q1 is the vector composed of the other configuration variables of
+    ///  \li q_in is the vector composed of other configuration variables of
     ///      q,
-    ///  g is a differentiable function with values in  a Lie group.
+    ///  f, g are differentiable functions with values in  a Lie group.
     ///
     ///  This class is mainly used to create hpp::constraints::Explicit
     ///  instances.
@@ -92,7 +92,7 @@ namespace hpp {
        const segments_t& inputConf, const segments_t& inputVelocity,
        const segments_t& outputConf, const segments_t& outputVelocity);
 
-      /// Get function that maps input variables to output variables
+      /// Get function f that maps input variables to output variables
       const DifferentiableFunctionPtr_t& inputToOutput () const;
 
     protected:
@@ -127,7 +127,7 @@ namespace hpp {
       /// Compute g (q_out) - f (q_in)
       void impl_compute (LiegroupElement& result, vectorIn_t argument) const;
 
-      /// Compute Jacobian of q_{output} - f (q_{input})
+      /// Compute Jacobian of g (q_out) - f (q_in) with respect to q.
       void impl_jacobian (matrixOut_t jacobian, vectorIn_t arg) const;
 
     private:

--- a/include/hpp/constraints/fwd.hh
+++ b/include/hpp/constraints/fwd.hh
@@ -141,6 +141,7 @@ namespace hpp {
 
     HPP_PREDEF_CLASS (Implicit);
     typedef boost::shared_ptr <Implicit> ImplicitPtr_t;
+    typedef std::vector < constraints::ImplicitPtr_t > NumericalConstraints_t;
 
     enum ComparisonType {
       Equality,
@@ -166,6 +167,7 @@ namespace hpp {
     HPP_PREDEF_CLASS (LockedJoint);
     typedef boost::shared_ptr <LockedJoint> LockedJointPtr_t;
     typedef boost::shared_ptr <const LockedJoint> LockedJointConstPtr_t;
+    typedef std::vector <LockedJointPtr_t> LockedJoints_t;
 
     typedef ExplicitConstraintSet ExplicitSolver HPP_CONSTRAINTS_DEPRECATED;
     typedef solver::HierarchicalIterative HierarchicalIterativeSolver

--- a/include/hpp/constraints/impl/matrix-view-operation.hh
+++ b/include/hpp/constraints/impl/matrix-view-operation.hh
@@ -66,7 +66,7 @@ void CwiseBinaryOpImpl<BinaryOp, LHS_TYPE, RHS_TYPE, Dense>::evalTo            \
                       Functor, Dense2Dense, Scalar> {                          \
       typedef CwiseBinaryOp<BinaryOp, LHS_TYPE, RHS_TYPE> CwiseDerived;        \
       static EIGEN_STRONG_INLINE void run                                      \
-        (Derived& dst, const CwiseDerived& o, const Functor& func)             \
+        (Derived& dst, const CwiseDerived& o, const Functor&)                  \
       { o.evalTo(dst); }                                                       \
     };
 

--- a/include/hpp/constraints/solver/by-substitution.hh
+++ b/include/hpp/constraints/solver/by-substitution.hh
@@ -179,8 +179,8 @@ namespace hpp {
         /// \textbf{q}_{res} = \left(I_n -
         /// J^{+}J(\textbf{q}_{from})\right) (\textbf{v})
         /// \f]
-        void projectVectorOnKernel (vectorIn_t from, vectorIn_t velocity,
-                                    vectorOut_t result) const;
+        void projectVectorOnKernel (ConfigurationIn_t from, vectorIn_t velocity,
+                                    ConfigurationOut_t result) const;
 
         /// Project configuration "to" on constraint tangent space in "from"
         ///

--- a/include/hpp/constraints/solver/by-substitution.hh
+++ b/include/hpp/constraints/solver/by-substitution.hh
@@ -63,28 +63,8 @@ namespace hpp {
         : public solver::HierarchicalIterative
       {
       public:
-        BySubstitution (const LiegroupSpacePtr_t& configSpace) :
-          HierarchicalIterative(configSpace),
-          explicit_ (configSpace->nq (), configSpace->nv ()),
-          JeExpanded_ (configSpace->nv (), configSpace->nv ())
-            {}
-
-        BySubstitution (const BySubstitution& other) :
-          HierarchicalIterative (other), explicit_ (other.explicit_),
-          Je_ (other.Je_), JeExpanded_ (other.JeExpanded_)
-          {
-            // TODO remove me
-            for (LockedJoints_t::const_iterator it = lockedJoints_.begin ();
-                 it != lockedJoints_.end (); ++it) {
-              LockedJointPtr_t lj = HPP_STATIC_PTR_CAST
-                (LockedJoint, (*it)->copy ());
-              if (!explicitConstraintSet().replace
-                  ((*it)->explicitFunction(), lj->explicitFunction()))
-                throw std::runtime_error
-                  ("Could not replace lockedJoint function");
-              lockedJoints_.push_back (lj);
-            }
-          }
+        BySubstitution (const LiegroupSpacePtr_t& configSpace);
+        BySubstitution (const BySubstitution& other);
 
         virtual ~BySubstitution () {}
 

--- a/include/hpp/constraints/solver/hierarchical-iterative.hh
+++ b/include/hpp/constraints/solver/hierarchical-iterative.hh
@@ -153,10 +153,18 @@ namespace hpp {
       /// system of equations can be modified by methods
       /// HierarchicalIterative::rightHandSideFromInput,
       /// HierarchicalIterative::rightHandSide.
+      ///
+      /// \note Free variables
+      ///
+      /// Some variables can be locked, or computed explicitely. In this case,
+      /// the iterative resolution will only change the other variables called
+      /// free variables. \sa methods
+      /// \li \ref void freeVariables (const Indices_t& indices) and
+      /// \li \ref void freeVariables (const Indices_t& indices).
       class HPP_CONSTRAINTS_DLLAPI HierarchicalIterative
       {
       public:
-        typedef Eigen::ColBlockIndices Reduction_t;
+        typedef Eigen::RowBlockIndices Indices_t;
         typedef lineSearch::FixedSequence DefaultLineSearch;
 
         enum Status {
@@ -290,24 +298,28 @@ namespace hpp {
         /// \name Parameters
         /// \{
 
-        /// Set the velocity variable that must be changed.
+        /// Set free velocity variables
+        ///
         /// The other variables will be left unchanged by the iterative
-        /// algorithm.
-        void reduction (const segments_t intervals)
+        /// resolution.
+        ///
+        /// \param intervals set of index intervals
+        void freeVariables (const segments_t intervals)
         {
-          reduction_ = Reduction_t();
+          freeVariables_ = Indices_t();
           for (std::size_t i = 0; i < intervals.size(); ++i)
-            reduction_.addCol(intervals[i].first, intervals[i].second);
-          reduction_.updateIndices<true, true, true>();
+            freeVariables_.addRow (intervals[i].first, intervals[i].second);
+          freeVariables_.updateIndices<true, true, true>();
           update ();
         }
 
-        /// Set the velocity variable that must be changed.
+        /// Set free velocity variables
+        ///
         /// The other variables will be left unchanged by the iterative
-        /// algorithm.
-        void reduction (const Reduction_t& reduction)
+        /// resolution.
+        void freeVariables (const Indices_t& indices)
         {
-          reduction_ = reduction;
+          freeVariables_ = indices;
           update ();
         }
 
@@ -525,7 +537,8 @@ namespace hpp {
         LiegroupSpacePtr_t configSpace_;
         size_type dimension_, reducedDimension_;
         bool lastIsOptional_;
-        Reduction_t reduction_;
+        /// Unknown of the set of implicit constraints
+        Indices_t freeVariables_;
         Saturation_t saturate_;
         /// Members moved from core::ConfigProjector
         NumericalConstraints_t functions_;

--- a/include/hpp/constraints/solver/hierarchical-iterative.hh
+++ b/include/hpp/constraints/solver/hierarchical-iterative.hh
@@ -180,6 +180,8 @@ namespace hpp {
 
         HierarchicalIterative (const LiegroupSpacePtr_t& configSpace);
 
+        HierarchicalIterative (const HierarchicalIterative& other);
+
         virtual ~HierarchicalIterative () {}
 
         /// \name Problem definition

--- a/include/hpp/constraints/solver/hierarchical-iterative.hh
+++ b/include/hpp/constraints/solver/hierarchical-iterative.hh
@@ -130,11 +130,8 @@ namespace hpp {
       /// \note Lie group
       ///
       /// The unknowns \f$\mathbf{q}\f$ may take values in a more general set
-      /// than the configuration space of a robot. This set should be a Cartesian
-      /// product of Lie groups. In this case, the user can provide a method that
-      /// computes the exponential map of a tangent vector.
-      /// \sa HierarchicalIterative::Integration_t and
-      /// HierarchicalIterative::integration.
+      /// than the configuration space of a robot. This set should be a
+      /// Cartesian product of Lie groups: hpp::pinocchio::LiegroupSpace.
       ///
       /// \note Saturation
       ///
@@ -168,27 +165,31 @@ namespace hpp {
           INFEASIBLE,
           SUCCESS
         };
-        /// This function integrates velocity during unit time, from argument.
-        /// It should be robust to cases where from and result points to the
-        /// same vector in memory (aliasing)
-        typedef boost::function<void (vectorIn_t from, vectorIn_t velocity, vectorOut_t result)> Integration_t;
         /// This function checks which degrees of freedom are saturated.
         ///
-        /// \param result a configuration
-        ///
-        /// For each degree of freedom, saturation is set to
+        /// \param q a configuration,
+        /// \retval qSat configuration after saturing values out of bounds
+        /// \retval saturation vector: for each degree of freedom, saturation
+        ///         is set to
         /// \li -1 if the lower bound is reached,
         /// \li  1 if the upper bound is reached,
         /// \li  0 otherwise.
-        typedef boost::function<bool (vectorIn_t result, Eigen::VectorXi& saturation)> Saturation_t;
+        typedef boost::function<bool (vectorIn_t q, vectorOut_t qSat,
+                                      Eigen::VectorXi& saturation)>
+          Saturation_t;
 
-        HierarchicalIterative (const std::size_t& argSize,
-                               const std::size_t derSize);
+        HierarchicalIterative (const LiegroupSpacePtr_t& configSpace);
 
         virtual ~HierarchicalIterative () {}
 
         /// \name Problem definition
         /// \{
+
+        /// Check whether a numerical constraint has been added
+        /// \param numericalConstraint numerical constraint
+        /// \return true if numerical constraint is already in the solver
+        ///         whatever the passive dofs are.
+        bool contains (const ImplicitPtr_t& numericalConstraint) const;
 
         /// Add an implicit equality constraint
         ///
@@ -212,18 +213,6 @@ namespace hpp {
         /// \param comp comparison type. See class documentation for details.
         void add (const DifferentiableFunctionPtr_t& f, const std::size_t& priority,
                   const ComparisonTypes_t& comp);
-
-        /// Set the integration function
-        void integration (const Integration_t& integrate)
-        {
-          integrate_ = integrate;
-        }
-
-        /// Get the integration function
-        const Integration_t& integration () const
-        {
-          return integrate_;
-        }
 
         /// Set the saturation function
         void saturation (const Saturation_t& saturate)
@@ -478,11 +467,8 @@ namespace hpp {
           return dq_;
         }
 
-        virtual void integrate(vectorIn_t from, vectorIn_t velocity, vectorOut_t result) const
-        {
-          integrate_ (from, velocity, result);
-        }
-
+        virtual void integrate(vectorIn_t from, vectorIn_t velocity,
+                               vectorOut_t result) const;
         /// \}
 
         virtual std::ostream& print (std::ostream& os) const;
@@ -534,22 +520,29 @@ namespace hpp {
         size_type maxIterations_;
 
         std::vector<DifferentiableFunctionStack> stacks_;
-        size_type argSize_, derSize_;
+        LiegroupSpacePtr_t configSpace_;
         size_type dimension_, reducedDimension_;
         bool lastIsOptional_;
         Reduction_t reduction_;
-        Integration_t integrate_;
         Saturation_t saturate_;
+        /// Members moved from core::ConfigProjector
+        NumericalConstraints_t functions_;
+        LockedJoints_t lockedJoints_;
+
         /// The smallest non-zero singular value
         mutable value_type sigma_;
 
         mutable vector_t dq_, dqSmall_;
         mutable matrix_t projector_, reducedJ_;
         mutable Eigen::VectorXi saturation_, reducedSaturation_;
+        mutable Configuration_t qSat_;
         mutable ArrayXb tmpSat_;
         mutable value_type squaredNorm_;
         mutable std::vector<Data> datas_;
         mutable SVD_t svd_;
+        mutable vector_t OM_;
+        mutable vector_t OP_;
+
 
         mutable ::hpp::statistics::SuccessStatistics statistics_;
 

--- a/include/hpp/constraints/solver/impl/hierarchical-iterative.hh
+++ b/include/hpp/constraints/solver/impl/hierarchical-iterative.hh
@@ -100,7 +100,7 @@ namespace hpp {
         const value_type r = solver.residualError() / solver.squaredErrorThreshold();
         const value_type alpha = C - K * std::tanh(a * r + b);
         darg *= alpha;
-        solver.integration() (arg, darg, arg);
+        solver.integrate (arg, darg, arg);
         return true;
       }
     }

--- a/include/hpp/constraints/symbolic-function.hh
+++ b/include/hpp/constraints/symbolic-function.hh
@@ -54,7 +54,7 @@ namespace hpp {
             const typename Traits<Expression>::Ptr_t expr,
             std::vector <bool> mask)
         {
-          assert (mask.size() == expr->value().size());
+          assert (mask.size() == (std::size_t) expr->value().size());
           Ptr_t ptr (new SymbolicFunction (name,robot,expr,mask));
           ptr->init (ptr);
           return ptr;

--- a/src/explicit-constraint-set.cc
+++ b/src/explicit-constraint-set.cc
@@ -32,6 +32,7 @@ namespace hpp {
     typedef Eigen::MatrixBlocksRef<false, false> MatrixBlocksRef;
 
     namespace {
+      /// Append all indices of a set of segments to a queue of indices
       void append (const Eigen::RowBlockIndices& rbi, std::queue<size_type>& q) {
         for (std::size_t i = 0; i < rbi.indices().size(); ++i)
           for (size_type j = 0; j < rbi.indices()[i].second; ++j)
@@ -176,12 +177,14 @@ namespace hpp {
         return -1;
       // Check that it does not insert a loop.
       std::queue<size_type> idxArg;
+      // Put all indices of inArg into idxArg
       append(inArg, idxArg);
       while (!idxArg.empty()) {
         // iArg must be computed before f
         size_type iArg = idxArg.back();
         idxArg.pop();
-        // iArg is an output of f -> cannot be computed before f
+        // iArg is an output of the new function -> new function should be
+        // computed earlier -> incompatible.
         if (iArg >= outIdx.first && iArg < outIdx.first + outIdx.second) return -1;
         // iArg is not computed by any function
         if (argFunction_[iArg] < 0) continue;
@@ -198,8 +201,8 @@ namespace hpp {
       // Update the free dofs
       outArgs_.addRow(outIdx.first, outIdx.second);
       outArgs_.updateIndices<true, true, true>();
-      freeArgs_ = RowBlockIndices
-        (BlockIndex::difference (BlockIndex::segment_t(0, argSize_),
+      notOutArgs_ = RowBlockIndices
+        (BlockIndex::difference (BlockIndex::segment_t(0, nq_),
                                  outArgs_.indices()));
 
       BlockIndex::add (inArgs_.m_rows, inArg.rows());
@@ -210,8 +213,8 @@ namespace hpp {
 
       outDers_.addRow(outDerIdx.first, outDerIdx.second);
       outDers_.updateIndices<true, true, true>();
-      freeDers_ = ColBlockIndices
-        (BlockIndex::difference(BlockIndex::segment_t(0, derSize_),
+      notOutDers_ = ColBlockIndices
+        (BlockIndex::difference(BlockIndex::segment_t(0, nv_),
                                 outDers_.indices()));
 
       BlockIndex::add (inDers_.m_cols, inDer.cols());
@@ -223,7 +226,7 @@ namespace hpp {
       /// Computation order
       std::size_t order = 0;
       computationOrder_.resize(functions_.size());
-      inOutDependencies_ = Eigen::MatrixXi::Zero(functions_.size(), derSize_);
+      inOutDependencies_ = Eigen::MatrixXi::Zero(functions_.size(), nv_);
       Computed_t computed(functions_.size(), false);
       for(std::size_t i = 0; i < functions_.size(); ++i)
         computeOrder(i, order, computed);
@@ -280,20 +283,20 @@ namespace hpp {
     {
       // TODO this could be done only on the complement of inDers_
       jacobian.setZero();
-      MatrixBlocksRef (freeDers_, freeDers_)
+      MatrixBlocksRef (notOutDers_, notOutDers_)
         .lview (jacobian).setIdentity();
       // Compute the function jacobians
       for(std::size_t i = 0; i < functions_.size(); ++i) {
-        const Function& f = functions_[i];
-        f.qin = f.inArg.rview(arg);
-        if (f.ginv) f.f->value(f.value, f.qin);
-        f.f->jacobian(f.jacobian, f.qin);
-        if (f.equalityIndices.nbIndices() > 0)
-          f.f->outputSpace ()->dIntegrate_dq (f.value, f.rightHandSide, f.jacobian);
-        if (f.ginv) {
-          f.value += f.rightHandSide;
-          f.ginv->jacobian(f.jGinv, f.value.vector());
-          f.jacobian.applyOnTheLeft(f.jGinv);
+        const Function& E = functions_[i];
+        E.qin = E.inArg.rview(arg);
+        if (E.ginv) E.f->value(E.value, E.qin);
+        E.f->jacobian(E.jacobian, E.qin);
+        if (E.equalityIndices.nbIndices() > 0)
+          E.f->outputSpace ()->dIntegrate_dq (E.value, E.rightHandSide, E.jacobian);
+        if (E.ginv) {
+          E.value += E.rightHandSide;
+          E.ginv->jacobian(E.jGinv, E.value.vector());
+          E.jacobian.applyOnTheLeft(E.jGinv);
         }
       }
       for(std::size_t i = 0; i < functions_.size(); ++i) {
@@ -302,46 +305,47 @@ namespace hpp {
     }
 
     void ExplicitConstraintSet::computeJacobian
-    (const std::size_t& iF, matrixOut_t J) const
+    (const std::size_t& iE, matrixOut_t J) const
     {
-      const Function& f = functions_[iF];
-      matrix_t Jg (MatrixBlocksRef (f.inDer, inDers_).rview(J));
-      MatrixBlocksRef (f.outDer, inDers_).lview (J) = f.jacobian * Jg;
+      const Function& E = functions_[iE];
+      matrix_t Jin (MatrixBlocksRef (E.inDer, inDers_).rview(J));
+      // Jout = E.jacobian * Jin
+      MatrixBlocksRef (E.outDer, inDers_).lview (J) = E.jacobian * Jin;
     }
 
     void ExplicitConstraintSet::computeOrder
-    (const std::size_t& iF, std::size_t& iOrder, Computed_t& computed)
+    (const std::size_t& iE, std::size_t& iOrder, Computed_t& computed)
     {
-      if (computed[iF]) return;
-      const Function& f = functions_[iF];
-      for (std::size_t i = 0; i < f.inDer.indices().size(); ++i) {
-        const BlockIndex::segment_t& segment = f.inDer.indices()[i];
+      if (computed[iE]) return;
+      const Function& E = functions_[iE];
+      for (std::size_t i = 0; i < E.inDer.indices().size(); ++i) {
+        const BlockIndex::segment_t& segment = E.inDer.indices()[i];
         for (size_type j = 0; j < segment.second; ++j) {
           if (derFunction_[segment.first + j] < 0) {
-            inOutDependencies_(iF, segment.first + j) += 1;
+            inOutDependencies_(iE, segment.first + j) += 1;
           } else {
             assert((std::size_t)derFunction_[segment.first + j] < functions_.size());
             computeOrder(derFunction_[segment.first + j], iOrder, computed);
-            inOutDependencies_.row(iF) += inOutDependencies_.row(derFunction_[segment.first + j]);
+            inOutDependencies_.row(iE) += inOutDependencies_.row(derFunction_[segment.first + j]);
           }
         }
       }
-      computationOrder_[iOrder] = iF;
+      computationOrder_[iOrder] = iE;
       ++iOrder;
-      computed[iF] = true;
+      computed[iE] = true;
     }
 
     vector_t ExplicitConstraintSet::rightHandSideFromInput (vectorIn_t arg)
     {
       for (std::size_t i = 0; i < functions_.size (); ++i) {
-        Function& f = functions_[i];
-        f.qin = f.inArg.rview(arg); // q_{in}
-        f.f->value(f.value, f.qin); // f (q_{in})
-        f.qout = f.outArg.rview(arg); // q_{out}
-        if (f.g) f.g->value(f.expected, f.qout); // g (q_{out})
-        else     f.expected.vector() = f.qout;
-        vector_t rhs = f.expected - f.value;  // g (q_{out}) - f (q_{in})
-        f.equalityIndices.lview(f.rightHandSide) = f.equalityIndices.rview(rhs);
+        Function& E = functions_[i];
+        E.qin = E.inArg.rview(arg);
+        E.f->value(E.value, E.qin);
+        E.qout = E.outArg.rview(arg);
+        if (E.g) E.g->value(E.expected, E.qout);
+        else     E.expected.vector() = E.qout;
+        vector_t rhs = E.expected - E.value;
+        E.equalityIndices.lview(E.rightHandSide) = E.equalityIndices.rview(rhs);
       }
       return rightHandSide();
     }
@@ -350,8 +354,8 @@ namespace hpp {
     (const DifferentiableFunctionPtr_t& df, vectorIn_t arg)
     {
       for (std::size_t i = 0; i < functions_.size (); ++i) {
-        Function& f = functions_[i];
-        if (f.f == df) {
+        Function& E = functions_[i];
+        if (E.f == df) {
           rightHandSideFromInput (i, arg);
           return true;
         }
@@ -363,26 +367,26 @@ namespace hpp {
     (const size_type& fidx, vectorIn_t arg)
     {
       assert (fidx < (size_type) functions_.size());
-      Function& f = functions_[fidx];
+      Function& E = functions_[fidx];
 
       // Computes f(q1) and g(q2)
-      f.qin = f.inArg.rview(arg); // q_{in}
-      f.f->value(f.value, f.qin); // f (q_{in})
-      f.qout = f.outArg.rview(arg); // q_{out}
-      if (f.g) f.g->value(f.expected, f.qout); // g (q_{out})
-      else     f.expected.vector() = f.qout;
+      E.qin = E.inArg.rview(arg);
+      E.f->value(E.value, E.qin);
+      E.qout = E.outArg.rview(arg);
+      if (E.g) E.g->value(E.expected, E.qout);
+      else     E.expected.vector() = E.qout;
 
       // Set rhs = g(q2) - f(q1)
-      vector_t rhs = f.expected - f.value;
-      f.equalityIndices.lview(f.rightHandSide) = f.equalityIndices.rview(rhs);
+      vector_t rhs = E.expected - E.value;
+      E.equalityIndices.lview(E.rightHandSide) = E.equalityIndices.rview(rhs);
     }
 
     bool ExplicitConstraintSet::rightHandSide
     (const DifferentiableFunctionPtr_t& df, vectorIn_t rhs)
     {
       for (std::size_t i = 0; i < functions_.size (); ++i) {
-        Function& f = functions_[i];
-        if (f.f == df) {
+        Function& E = functions_[i];
+        if (E.f == df) {
           rightHandSide (i, rhs);
           return true;
         }
@@ -394,19 +398,19 @@ namespace hpp {
     (const size_type& i, vectorIn_t rhs)
     {
       assert (i < (size_type) functions_.size());
-      Function& f = functions_[i];
-      f.equalityIndices.lview(f.rightHandSide) = f.equalityIndices.rview(rhs);
+      Function& E = functions_[i];
+      E.equalityIndices.lview(E.rightHandSide) = E.equalityIndices.rview(rhs);
     }
 
     void ExplicitConstraintSet::rightHandSide (vectorIn_t rhs)
     {
       size_type row = 0;
       for (std::size_t i = 0; i < functions_.size (); ++i) {
-        Function& f = functions_[i];
+        Function& E = functions_[i];
 
-        f.equalityIndices.lview(f.rightHandSide)
-          = rhs.segment(row, f.equalityIndices.nbRows());
-        row += f.equalityIndices.nbRows();
+        E.equalityIndices.lview(E.rightHandSide)
+          = rhs.segment(row, E.equalityIndices.nbRows());
+        row += E.equalityIndices.nbRows();
       }
       assert (row == rhs.size());
     }
@@ -416,10 +420,10 @@ namespace hpp {
       vector_t rhs(rightHandSideSize());
       size_type row = 0;
       for (std::size_t i = 0; i < functions_.size (); ++i) {
-        const Function& f = functions_[i];
-        const size_type nRows = f.equalityIndices.nbRows();
+        const Function& E = functions_[i];
+        const size_type nRows = E.equalityIndices.nbRows();
         vector_t::SegmentReturnType seg = rhs.segment(row, nRows);
-        seg = f.equalityIndices.rview(f.rightHandSide);
+        seg = E.equalityIndices.rview(E.rightHandSide);
         row += nRows;
       }
       assert (row == rhs.size());
@@ -438,29 +442,29 @@ namespace hpp {
     {
       os << "ExplicitConstraintSet, " << functions_.size()
          << " functions." << incendl
-        << "Free args: " << freeArgs_ << iendl
+        << "Other args: " << notOutArgs_ << iendl
         << "Params: " << inArgs_ << " -> " << outArgs_ << iendl
         << "Dofs: "   << inDers_ << " -> " << outDers_ << iendl
         << "Functions" << incindent;
       for(std::size_t i = 0; i < functions_.size(); ++i) {
-        const Function& f = functions_[computationOrder_[i]];
-        os << iendl << i << ": " << f.inArg << " -> " << f.outArg
-          << incendl << *f.f
-          << decendl << "Rhs: " << condensed(f.rightHandSide)
-          << iendl   << "Equality: " << f.equalityIndices;
+        const Function& E = functions_[computationOrder_[i]];
+        os << iendl << i << ": " << E.inArg << " -> " << E.outArg
+          << incendl << *E.f
+          << decendl << "Rhs: " << condensed(E.rightHandSide)
+          << iendl   << "Equality: " << E.equalityIndices;
       }
       return os << decindent << decindent;
     }
 
     Eigen::MatrixXi ExplicitConstraintSet::inOutDofDependencies () const
     {
-      Eigen::MatrixXi iod (derSize(), inDers_.nbCols());
+      Eigen::MatrixXi iod (nv (), inDers_.nbCols());
       if (inDers_.nbCols() == 0) return iod;
       Eigen::RowVectorXi tmp (inDers_.nbCols());
       for(std::size_t i = 0; i < functions_.size(); ++i) {
-        const Function& f = functions_[i];
+        const Function& E = functions_[i];
         tmp = inDers_.rview (inOutDependencies_.row(i));
-        f.outDer.lview(iod).rowwise() = tmp;
+        E.outDer.lview(iod).rowwise() = tmp;
       }
       return outDers_.rview(iod);
     }

--- a/src/explicit-constraint-set.cc
+++ b/src/explicit-constraint-set.cc
@@ -156,8 +156,17 @@ namespace hpp {
       // It is done in the while loop below
       // Sanity check: is it explicit ?
       for (std::size_t i = 0; i < inArg.indices().size(); ++i)
-        if (BlockIndex::overlap(inArg.indices()[i], outIdx))
-          return -1;
+        if (BlockIndex::overlap(inArg.indices()[i], outIdx)) {
+          size_type f0 (inArg.indices()[i].first);
+          size_type s0 (f0 + inArg.indices()[i].second - 1);
+          size_type f1 (outIdx.first);
+          size_type s1 (f1 + outIdx.second - 1);
+          std::ostringstream oss;
+          oss << "Explicit constraint \"" << f->name () << "\" is malformed.";
+          oss << " input [" << f0 << "," << s0
+              << "] and output [" << f1 << "," << s1 << "] segments overlap.";
+            throw std::logic_error (oss.str ().c_str ());
+        }
       // Sanity check: Comparison type must be either EqualToZero or Equality
       assert (comp.size() == (std::size_t)f->outputDerivativeSize());
       for (std::size_t i = 0; i < comp.size(); ++i)

--- a/src/explicit.cc
+++ b/src/explicit.cc
@@ -99,6 +99,44 @@ namespace hpp {
       return shPtr;
     }
 
+    ExplicitPtr_t Explicit::create
+    (const LiegroupSpacePtr_t& configSpace,
+     const DifferentiableFunctionPtr_t& function,
+     const DifferentiableFunctionPtr_t& g,
+     const DifferentiableFunctionPtr_t& ginv,
+     const segments_t& inputConf,
+     const segments_t& inputVelocity,
+     const segments_t& outputConf,
+     const segments_t& outputVelocity,
+     const ComparisonTypes_t& comp)
+    {
+      Explicit* ptr = new Explicit
+	(configSpace, function, g, ginv, inputConf, inputVelocity, outputConf,
+         outputVelocity, defaultCompTypes(outputVelocity,comp));
+      ExplicitPtr_t shPtr (ptr);
+      ExplicitWkPtr_t wkPtr (shPtr);
+      ptr->init (wkPtr);
+      return shPtr;
+    }
+
+    ExplicitPtr_t Explicit::create
+    (const LiegroupSpacePtr_t& configSpace,
+     const DifferentiableFunctionPtr_t& function,
+     const segments_t& inputConf,
+     const segments_t& inputVelocity,
+     const segments_t& outputConf,
+     const segments_t& outputVelocity,
+     const ComparisonTypes_t& comp)
+    {
+      Explicit* ptr = new Explicit
+	(configSpace, function, inputConf, inputVelocity, outputConf,
+         outputVelocity, defaultCompTypes(outputVelocity,comp));
+      ExplicitPtr_t shPtr (ptr);
+      ExplicitWkPtr_t wkPtr (shPtr);
+      ptr->init (wkPtr);
+      return shPtr;
+    }
+
     ExplicitPtr_t Explicit::createCopy
     (const ExplicitPtr_t& other)
     {
@@ -145,6 +183,48 @@ namespace hpp {
      const ComparisonTypes_t& comp) :
       Implicit (explicit_::BasicFunction::create
                 (robot, explicitFunction, inputConf, inputVelocity,
+                 outputConf, outputVelocity),
+                comp),
+      inputToOutput_ (explicitFunction),
+      inputConf_ (inputConf),
+      inputVelocity_ (inputVelocity),
+      outputConf_ (outputConf),
+      outputVelocity_ (outputVelocity)
+    {
+    }
+
+    Explicit::Explicit
+    (const LiegroupSpacePtr_t& configSpace,
+     const DifferentiableFunctionPtr_t& explicitFunction,
+     const DifferentiableFunctionPtr_t& g,
+     const DifferentiableFunctionPtr_t& ginv,
+     const segments_t& inputConf,
+     const segments_t& inputVelocity,
+     const segments_t& outputConf,
+     const segments_t& outputVelocity,
+     const ComparisonTypes_t& comp) :
+      Implicit (explicit_::GenericFunction::create
+                (configSpace, explicitFunction, g, inputConf, inputVelocity,
+                 outputConf, outputVelocity),
+                comp),
+      inputToOutput_ (explicitFunction), g_ (g), ginv_ (ginv),
+      inputConf_ (inputConf),
+      inputVelocity_ (inputVelocity),
+      outputConf_ (outputConf),
+      outputVelocity_ (outputVelocity)
+    {
+    }
+
+    Explicit::Explicit
+    (const LiegroupSpacePtr_t& configSpace,
+     const DifferentiableFunctionPtr_t& explicitFunction,
+     const segments_t& inputConf,
+     const segments_t& inputVelocity,
+     const segments_t& outputConf,
+     const segments_t& outputVelocity,
+     const ComparisonTypes_t& comp) :
+      Implicit (explicit_::BasicFunction::create
+                (configSpace, explicitFunction, inputConf, inputVelocity,
                  outputConf, outputVelocity),
                 comp),
       inputToOutput_ (explicitFunction),

--- a/src/explicit/function.cc
+++ b/src/explicit/function.cc
@@ -52,7 +52,7 @@ namespace hpp {
 
       vectorIn_t qOut_, f_qIn_;
       vector_t result_;
-    }; // struct JacobianVisitor
+    }; // struct ValueVisitor
 
     template <> inline void ValueVisitor::operator () <SE3> (const SE3&)
     {

--- a/src/locked-joint.cc
+++ b/src/locked-joint.cc
@@ -137,7 +137,7 @@ namespace hpp {
     LockedJoint::LockedJoint (const JointPtr_t& joint,
                               const LiegroupElement& value) :
       Explicit (
-          joint->robot(),
+                joint->robot()->configSpace (),
           makeFunction (value, joint->name()),
           segments_t(), // input conf
           segments_t(), // input vel
@@ -155,7 +155,7 @@ namespace hpp {
     LockedJoint::LockedJoint (const JointPtr_t& joint, const size_type index,
         vectorIn_t value) :
       Explicit (
-          joint->robot(),
+                joint->robot()->configSpace (),
           makeFunction (
             LiegroupElement (value, LiegroupSpace::Rn (joint->configSize () - index)),
             "partial_" + joint->name()),
@@ -176,7 +176,7 @@ namespace hpp {
     LockedJoint::LockedJoint (const DevicePtr_t& dev, const size_type index,
         vectorIn_t value) :
       Explicit (
-          dev,
+                dev->configSpace (),
           makeFunction (
             LiegroupElement (value, LiegroupSpace::Rn (value.size ())),
             dev->name() + "_extraDof" + numToStr (index)),

--- a/src/solver/by-substitution.cc
+++ b/src/solver/by-substitution.cc
@@ -211,10 +211,20 @@ namespace hpp {
         return BlockIndex::fromLogicalExpression(out.array().cast<bool>());
       }
 
+      // Note that the jacobian of the implicit constraints have already
+      // been computed by computeValue <true>
+      // The Jacobian of the implicit constraint of priority i is stored in
+      // datas_ [i].jacobian
       void BySubstitution::updateJacobian (vectorIn_t arg) const
       {
         if (explicit_.inDers().nbCols() == 0) return;
-        // Compute Je_
+        /*                                ------
+                         /   in          in u out \
+                         |                        |
+                   Je_ = |   df                   |
+                         |  ---- (qin)      0     |
+                         \  dqin                  /
+        */
         explicit_.jacobian(JeExpanded_, arg);
         Je_ = explicit_.jacobianNotOutToOut (JeExpanded_);
 

--- a/src/solver/by-substitution.cc
+++ b/src/solver/by-substitution.cc
@@ -287,7 +287,7 @@ namespace hpp {
       }
 
       void BySubstitution::projectVectorOnKernel
-      (vectorIn_t arg, vectorIn_t darg, vectorOut_t result) const
+      (ConfigurationIn_t arg, vectorIn_t darg, ConfigurationOut_t result) const
       {
         if (functions_.empty ()) {
           result = darg;

--- a/src/solver/by-substitution.cc
+++ b/src/solver/by-substitution.cc
@@ -189,7 +189,7 @@ namespace hpp {
 
       void BySubstitution::explicitConstraintSetHasChanged()
       {
-        reduction(explicit_.freeDers());
+        reduction(explicit_.notOutDers ());
       }
 
       segments_t BySubstitution::implicitDof () const
@@ -216,7 +216,7 @@ namespace hpp {
         if (explicit_.inDers().nbCols() == 0) return;
         // Compute Je_
         explicit_.jacobian(JeExpanded_, arg);
-        Je_ = explicit_.viewJacobian(JeExpanded_);
+        Je_ = explicit_.jacobianNotOutToOut (JeExpanded_);
 
         hppDnum (info, "Jacobian of explicit system is" << iendl <<
                  setpyformat << pretty_print(Je_));

--- a/src/solver/by-substitution.cc
+++ b/src/solver/by-substitution.cc
@@ -51,6 +51,28 @@ namespace hpp {
           (new ActiveSetDifferentiableFunction(function, pdofs));
       }
 
+      BySubstitution::BySubstitution (const LiegroupSpacePtr_t& configSpace) :
+        HierarchicalIterative(configSpace),
+        explicit_ (configSpace->nq (), configSpace->nv ()),
+        JeExpanded_ (configSpace->nv (), configSpace->nv ())
+      {}
+
+      BySubstitution::BySubstitution (const BySubstitution& other) :
+        HierarchicalIterative (other), explicit_ (other.explicit_),
+        Je_ (other.Je_), JeExpanded_ (other.JeExpanded_)
+      {
+        // TODO remove me
+        for (LockedJoints_t::const_iterator it = lockedJoints_.begin ();
+             it != lockedJoints_.end (); ++it) {
+          LockedJointPtr_t lj = HPP_STATIC_PTR_CAST
+            (LockedJoint, (*it)->copy ());
+          if (!explicitConstraintSet().replace
+              ((*it)->explicitFunction(), lj->explicitFunction()))
+            throw std::runtime_error
+              ("Could not replace lockedJoint function");
+        }
+      }
+
       bool BySubstitution::add (const ImplicitPtr_t& nm,
                                 const segments_t& passiveDofs,
                                 const std::size_t priority)

--- a/src/solver/hierarchical-iterative.cc
+++ b/src/solver/hierarchical-iterative.cc
@@ -100,23 +100,38 @@ namespace hpp {
       }
 
       HierarchicalIterative::HierarchicalIterative
-      (const LiegroupSpacePtr_t& configSpace)
-        : stacks_ (),
-          configSpace_ (configSpace),
-          dimension_ (0),
-          lastIsOptional_ (false),
-          reduction_ (),
-          functions_ (),
-          lockedJoints_ (),
-          saturation_ (configSpace->nv ()),
-          qSat_ (configSpace_->nv ()),
-          datas_(),
-          OM_ (configSpace->nv ()),
-          OP_ (configSpace->nv ()),
-          statistics_ ("HierarchicalIterative")
-
+      (const LiegroupSpacePtr_t& configSpace) :
+        squaredErrorThreshold_ (0), inequalityThreshold_ (0),
+        maxIterations_ (0), stacks_ (), configSpace_ (configSpace),
+        dimension_ (0), reducedDimension_ (0), lastIsOptional_ (false),
+        reduction_ (), saturate_ (), functions_ (), lockedJoints_ (),
+        sigma_ (0), dq_ (), dqSmall_ (), projector_ (), reducedJ_ (),
+        saturation_ (configSpace->nv ()), reducedSaturation_ (),
+        qSat_ (configSpace_->nq ()), tmpSat_ (), squaredNorm_ (0), datas_(),
+        svd_ (), OM_ (configSpace->nv ()), OP_ (configSpace->nv ()),
+        statistics_ ("HierarchicalIterative")
       {
         reduction_.addCol (0, configSpace_->nv ());
+      }
+
+      HierarchicalIterative::HierarchicalIterative
+      (const HierarchicalIterative& other) :
+        squaredErrorThreshold_ (other.squaredErrorThreshold_),
+        inequalityThreshold_ (other.inequalityThreshold_),
+        maxIterations_ (other.maxIterations_), stacks_ (other.stacks_),
+        configSpace_ (other.configSpace_), dimension_ (other.dimension_),
+        reducedDimension_ (other.reducedDimension_),
+        lastIsOptional_ (other.lastIsOptional_), reduction_ (other.reduction_),
+        saturate_ (other.saturate_), functions_ (other.functions_),
+        lockedJoints_ (other.lockedJoints_), sigma_(other.sigma_),
+        dq_ (other.dq_), dqSmall_ (other.dqSmall_),
+        projector_ (other.projector_),reducedJ_ (other.reducedJ_),
+        saturation_ (other.saturation_),
+        reducedSaturation_ (other.reducedSaturation_), qSat_ (other.qSat_),
+        tmpSat_ (other.tmpSat_), squaredNorm_ (other.squaredNorm_),
+        datas_ (other.datas_), svd_ (other.svd_),
+        statistics_ (other.statistics_)
+      {
       }
 
       bool HierarchicalIterative::contains

--- a/tests/solver-by-substitution.cc
+++ b/tests/solver-by-substitution.cc
@@ -47,6 +47,7 @@ using hpp::constraints::AffineFunctionPtr_t;
 using hpp::constraints::ConstantFunction;
 using hpp::constraints::ConstantFunctionPtr_t;
 using hpp::constraints::ExplicitConstraintSet;
+using hpp::constraints::Implicit;
 using hpp::constraints::matrix3_t;
 using hpp::constraints::LiegroupSpace;
 using hpp::constraints::JointPtr_t;
@@ -105,7 +106,7 @@ void test_quadratic ()
   solver.integration(simpleIntegration<-1,1>);
   solver.saturation(simpleSaturation<-1,1>);
 
-  solver.add (quad, 0);
+  solver.add (Implicit::create (quad));
   solver.explicitConstraintSet().add (expl, in, out, in, out);
   solver.explicitConstraintSetHasChanged();
 
@@ -173,7 +174,7 @@ void test_quadratic2 ()
   solver.integration(simpleIntegration<-1,1>);
   solver.saturation(simpleSaturation<-1,1>);
 
-  solver.add (quad, 0);
+  solver.add (Implicit::create (quad));
   solver.explicitConstraintSet().add (expl1, in1, out1, in1, out1);
   solver.explicitConstraintSet().add (expl2, in2, out2, in2, out2);
   solver.explicitConstraintSetHasChanged();
@@ -251,7 +252,7 @@ void test_quadratic3 ()
   solver.integration(simpleIntegration<-1,1>);
   solver.saturation(simpleSaturation<-1,1>);
 
-  solver.add (quad, 0);
+  solver.add (Implicit::create (quad));
   solver.explicitConstraintSet().add (expl1, in1, out1, in1, out1);
   solver.explicitConstraintSet().add (expl2, in2, out2, in2, out2);
   solver.explicitConstraintSet().add (expl3, in3, out3, in3, out3);
@@ -481,7 +482,9 @@ BOOST_AUTO_TEST_CASE(functions1)
   ///         q2 = C
 
   // f
-  solver.add(AffineFunctionPtr_t(new AffineFunction (matrix_t::Identity(2,3))), 0);
+  solver.add(Implicit::create
+             (AffineFunctionPtr_t (new AffineFunction
+                                   (matrix_t::Identity(2,3)))));
   // q1 = g(q3)
   Eigen::Matrix<value_type,1,1> Jg; Jg (0,0) = 1;
   Eigen::RowBlockIndices inArg; inArg.addRow (2,1);
@@ -500,7 +503,7 @@ BOOST_AUTO_TEST_CASE(functions1)
 
   // h
   matrix_t h (1,3); h << 0, 1, 0;
-  solver.add(AffineFunctionPtr_t(new AffineFunction (h)), 0);
+  solver.add(Implicit::create (AffineFunctionPtr_t(new AffineFunction (h))));
   BOOST_CHECK_EQUAL(solver.       dimension(), 3);
   BOOST_CHECK_EQUAL(solver.reducedDimension(), 2);
 
@@ -518,7 +521,7 @@ BOOST_AUTO_TEST_CASE(functions2)
   Eigen::Matrix<value_type, 2, 3> Jf;
   Jf << 1, 0, 0,
         0, 0, 1;
-  solver.add(AffineFunctionPtr_t(new AffineFunction (Jf)), 0);
+  solver.add(Implicit::create (AffineFunctionPtr_t(new AffineFunction (Jf))));
 
   Eigen::Matrix<value_type,1,1> Jg; Jg (0,0) = 1;
   Eigen::RowBlockIndices inArg; inArg.addRow (2,1);
@@ -536,7 +539,7 @@ BOOST_AUTO_TEST_CASE(functions2)
   /// q2 = g(q3)
   // This function should not be removed from the system.
   Eigen::Matrix<value_type, 1, 3> Jh; Jh << 0, 0, 1;
-  solver.add(AffineFunctionPtr_t(new AffineFunction (Jh)), 0);
+  solver.add(Implicit::create (AffineFunctionPtr_t(new AffineFunction (Jh))));
   BOOST_CHECK_EQUAL(solver.dimension(), 3);
 
   // We add to the system q3 = C
@@ -583,9 +586,12 @@ BOOST_AUTO_TEST_CASE(hybrid_solver)
   Transform3f tf2 (ee2->currentTransformation ());
   Transform3f tf3 (ee3->currentTransformation ());
 
-  solver.add(Orientation::create ("Orientation RAnkleRoll" , device, ee2, tf2), 0);
-  solver.add(Orientation::create ("Orientation LWristPitch", device, ee3, tf3), 0);
-  // solver.add(Position::create    ("Position"   , device, ee2, tf2), 0);
+  solver.add
+    (Implicit::create
+     (Orientation::create ("Orientation RAnkleRoll" , device, ee2, tf2)));
+  solver.add
+     (Implicit::create
+      (Orientation::create ("Orientation LWristPitch", device, ee3, tf3)));
 
   BOOST_CHECK(solver.numberStacks() == 1);
 

--- a/tests/solver-by-substitution.cc
+++ b/tests/solver-by-substitution.cc
@@ -631,5 +631,5 @@ BOOST_AUTO_TEST_CASE(hybrid_solver)
   vector_t dq (device->numberDof());
   dq.setRandom();
   qrand = tmp;
-  solver.projectOnKernel (qrand, dq, tmp);
+  solver.projectVectorOnKernel (qrand, dq, tmp);
 }

--- a/tests/solver-by-substitution.cc
+++ b/tests/solver-by-substitution.cc
@@ -100,10 +100,9 @@ void test_quadratic ()
   AffineFunctionPtr_t expl (new AffineFunction (B));
 
   // Make solver
-  BySubstitution solver (N, N);
+  BySubstitution solver (LiegroupSpace::Rn (N));
   solver.maxIterations(20);
   solver.errorThreshold(test_precision);
-  solver.integration(simpleIntegration<-1,1>);
   solver.saturation(simpleSaturation<-1,1>);
 
   solver.add (Implicit::create (quad));
@@ -168,10 +167,9 @@ void test_quadratic2 ()
   AffineFunctionPtr_t expl2 (new AffineFunction (C));
 
   // Make solver
-  BySubstitution solver (N, N);
+  BySubstitution solver (LiegroupSpace::Rn (N));
   solver.maxIterations(20);
   solver.errorThreshold(test_precision);
-  solver.integration(simpleIntegration<-1,1>);
   solver.saturation(simpleSaturation<-1,1>);
 
   solver.add (Implicit::create (quad));
@@ -246,10 +244,9 @@ void test_quadratic3 ()
   Quadratic::Ptr_t quad (new Quadratic (A, -d[0]));
 
   // Make solver
-  BySubstitution solver (N, N);
+  BySubstitution solver (LiegroupSpace::Rn (N));
   solver.maxIterations(20);
   solver.errorThreshold(test_precision);
-  solver.integration(simpleIntegration<-1,1>);
   solver.saturation(simpleSaturation<-1,1>);
 
   solver.add (Implicit::create (quad));
@@ -473,7 +470,7 @@ typedef boost::shared_ptr<ExplicitTransformation> ExplicitTransformationPtr_t;
 
 BOOST_AUTO_TEST_CASE(functions1)
 {
-  BySubstitution solver(3, 3);
+  BySubstitution solver(LiegroupSpace::R3 ());
 
   /// System:
   /// f (q1, q2) = 0
@@ -513,7 +510,7 @@ BOOST_AUTO_TEST_CASE(functions1)
 
 BOOST_AUTO_TEST_CASE(functions2)
 {
-  BySubstitution solver(3, 3);
+  BySubstitution solver(LiegroupSpace::R3 ());
 
   /// System:
   /// f (q1, q3) = 0
@@ -574,11 +571,10 @@ BOOST_AUTO_TEST_CASE(hybrid_solver)
   Configuration_t q = device->currentConfiguration (),
                   qrand = se3::randomConfiguration(device->model());
 
-  BySubstitution solver(device->configSize(), device->numberDof());
+  BySubstitution solver(device->configSpace ());
   solver.maxIterations(20);
   solver.errorThreshold(1e-3);
-  solver.integration(boost::bind(hpp::pinocchio::integrate<true, hpp::pinocchio::DefaultLieGroupMap>, device, _1, _2, _3));
-  solver.saturation(boost::bind(saturate, device, _1, _2));
+  solver.saturation(boost::bind(saturate, device, _1, _2, _3));
 
   device->currentConfiguration (q);
   device->computeForwardKinematics ();

--- a/tests/solver-by-substitution.cc
+++ b/tests/solver-by-substitution.cc
@@ -132,7 +132,8 @@ void test_quadratic ()
 
   x.setRandom();
   solver.explicitConstraintSet().solve(x);
-  expectedJ = 2 * solver.explicitConstraintSet().freeArgs().rview(x).eval().transpose() * Ar;
+  expectedJ = 2 * solver.explicitConstraintSet().notOutArgs().rview(x).eval().
+    transpose() * Ar;
 
   solver.computeValue<true> (x);
   solver.updateJacobian(x);
@@ -204,7 +205,8 @@ void test_quadratic2 ()
 
   x.setRandom();
   solver.explicitConstraintSet().solve(x);
-  expectedJ = 2 * solver.explicitConstraintSet().freeArgs().rview(x).eval().transpose() * Ar;
+  expectedJ = 2 * solver.explicitConstraintSet().notOutArgs().rview(x).eval().
+    transpose() * Ar;
 
   solver.computeValue<true> (x);
   solver.updateJacobian(x);
@@ -287,8 +289,8 @@ void test_quadratic3 ()
   x.setRandom();
   solver.explicitConstraintSet().solve(x);
   expectedJ = 2 *
-    (P * solver.explicitConstraintSet().freeArgs().rview(x).eval() + Xr_0).transpose()
-    * Ar * P;
+    (P * solver.explicitConstraintSet().notOutArgs().rview(x).eval() +
+     Xr_0).transpose() * Ar * P;
 
   solver.computeValue<true> (x);
   solver.updateJacobian(x);

--- a/tests/solver-hierarchical-iterative.cc
+++ b/tests/solver-hierarchical-iterative.cc
@@ -27,6 +27,7 @@
 #include <hpp/pinocchio/joint.hh>
 #include <hpp/pinocchio/configuration.hh>
 #include <hpp/pinocchio/simple-device.hh>
+#include <hpp/pinocchio/liegroup-space.hh>
 #include <hpp/constraints/generic-transformation.hh>
 #include <hpp/constraints/affine-function.hh>
 
@@ -38,6 +39,7 @@ const value_type test_precision = 1e-5;
 #define VECTOR2(x0, x1) ((hpp::constraints::vector_t (2) << x0, x1).finished())
 
 using Eigen::VectorXi;
+using hpp::pinocchio::LiegroupSpace;
 
 template <typename LineSearch>
 struct test_base
@@ -45,11 +47,10 @@ struct test_base
   solver::HierarchicalIterative solver;
   LineSearch ls;
 
-  test_base (const size_type& d) : solver(d, d)
+  test_base (const size_type& d) : solver(LiegroupSpace::Rn (d))
   {
     solver.maxIterations(20);
     solver.errorThreshold(test_precision);
-    solver.integration(simpleIntegration<0,1>);
     solver.saturation(simpleSaturation<0,1>);
   }
 
@@ -143,11 +144,10 @@ BOOST_AUTO_TEST_CASE(one_layer)
   Configuration_t q = device->currentConfiguration (),
                   qrand = se3::randomConfiguration(device->model());
 
-  solver::HierarchicalIterative solver(device->configSize(), device->numberDof());
+  solver::HierarchicalIterative solver(device->configSpace());
   solver.maxIterations(20);
   solver.errorThreshold(1e-3);
-  solver.integration(boost::bind(hpp::pinocchio::integrate<true, hpp::pinocchio::DefaultLieGroupMap>, device, _1, _2, _3));
-  solver.saturation(boost::bind(saturate, device, _1, _2));
+  solver.saturation(boost::bind(saturate, device, _1, _2, _3));
 
   device->currentConfiguration (q);
   device->computeForwardKinematics ();


### PR DESCRIPTION
* Refactor ExplicitConstraintSet: rename members and methods to better fit RSS
  paper notation and pinocchio convention:
  - argSize -> nq,
  - derSize -> nv,
  - freeArgs -> notOutArgs_,
  - freeDers -> notOutDers_,
  - viewJacobian -> jacobianNotOutToOut.
* Constructor and create methods of Explicit take a LiegroupSpace instead of a
  robot,
* Modify prototype of BySubstitution::projectVectorOnKernel
  - vectorIn_t -> ConfigurationIn_t,
  - vectorOut_t -> ConfigurationOut_t.
* In class HierarchicalIterative, rename "reduction" -> "free variables".
