### PR TITLE
[HierarchicalIterative] Add a method testing inclusion of manifolds

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,10 @@
                                                                 -*- outline -*-
 * Class HierarchicalIterative
-  - a bug in right hand side getter by constraint has been fixed.
+  - a bug in right hand side getter by constraint has been fixed,
+  - a getter to numerical constraints has been added. It returns the implicit
+    and explicit constraints,
+  - a method computing whether a solver solution manifold is a submanifold of
+    another solver solution manifold has been added.
 * Class Implicit has been cleaned up
   - methods setting and getting the right hand side are not deprecated anymore,
   - deprecated methods have been remove.

--- a/doc/right-hand-side.tex
+++ b/doc/right-hand-side.tex
@@ -17,7 +17,7 @@ We wish to represent relative pose constraints between two given frames $\fr_1$ 
 \begin{enumerate}
 \item setting Boolean masks should enable the user to define constraints with
   symmetries : only orientation is constrained, only the position of the origin of $\fr_2$ in $\fr_1$ is constrained, rotation around an axis is free ...
-\item when the relative pose is fully constrained, and $\fr_2$ is hold by a free-floating joint, if should be possible to expresse the position of this joint with respect to the position of $\fr_1$.
+\item when the relative pose is fully constrained, and $\fr_2$ is hold by a free-floating joint, it should be possible to express the position of this joint with respect to the position of $\fr_1$.
 \end{enumerate}
 
 \section {Explicit representation}

--- a/include/hpp/constraints/solver/hierarchical-iterative.hh
+++ b/include/hpp/constraints/solver/hierarchical-iterative.hh
@@ -441,6 +441,16 @@ namespace hpp {
         /// Returns the error vector
         void residualError(vectorOut_t error) const;
 
+        /// Inclusion of manifolds
+        ///
+        /// \param solver another solver
+        ///
+        /// This function returns true if the solution manifold of the solver
+        /// given as input is a submanifold of the solution manifold of this
+        /// solver. The function tests whether constraints of the input solver
+        /// are also in this solver.
+        bool definesSubmanifoldOf (const HierarchicalIterative& solver) const;
+
         /// \name Right hand side accessors
         /// \{
 

--- a/include/hpp/constraints/solver/hierarchical-iterative.hh
+++ b/include/hpp/constraints/solver/hierarchical-iterative.hh
@@ -401,6 +401,12 @@ namespace hpp {
           return stacks_[priority];
         }
 
+        /// Get constraints (implicit and explicit)
+        const NumericalConstraints_t& constraints () const
+        {
+          return constraints_;
+        }
+
         std::size_t numberStacks() const
         {
           return stacks_.size();

--- a/src/solver/hierarchical-iterative.cc
+++ b/src/solver/hierarchical-iterative.cc
@@ -619,6 +619,26 @@ namespace hpp {
         }
       }
 
+      bool HierarchicalIterative::definesSubmanifoldOf
+      (const HierarchicalIterative& solver) const
+      {
+        for (NumericalConstraints_t::const_iterator it
+               (solver.constraints ().begin ());
+             it != solver.constraints ().end (); ++it) {
+          bool isInThisSolver (false);
+          for (NumericalConstraints_t::const_iterator it1
+                 (this->constraints ().begin ());
+               it1 != this->constraints ().end (); ++it1) {
+            if (**it1 == **it) {
+              isInThisSolver = true;
+              break;
+            }
+          }
+          if (!isInThisSolver) return false;
+        }
+        return true;
+      }
+
       void HierarchicalIterative::computeDescentDirection () const
       {
         sigma_ = std::numeric_limits<value_type>::max();

--- a/tests/solver-by-substitution.cc
+++ b/tests/solver-by-substitution.cc
@@ -540,7 +540,10 @@ typedef boost::shared_ptr<ExplicitTransformation> ExplicitTransformationPtr_t;
 
 BOOST_AUTO_TEST_CASE(functions1)
 {
-  BySubstitution solver(LiegroupSpace::R3 ());
+  BySubstitution solver  (LiegroupSpace::R3 ());
+  BySubstitution solver1 (LiegroupSpace::R3 ());
+  BySubstitution solver2 (LiegroupSpace::R3 ());
+  BySubstitution solver3 (LiegroupSpace::R3 ());
 
   /// System:
   /// f (q1, q2) = 0
@@ -549,9 +552,16 @@ BOOST_AUTO_TEST_CASE(functions1)
   ///         q2 = C
 
   // f
-  solver.add(Implicit::create
-             (AffineFunctionPtr_t (new AffineFunction
-                                   (matrix_t::Identity(2,3)))));
+  ImplicitPtr_t impl (Implicit::create
+                      (AffineFunctionPtr_t (new AffineFunction
+                                            (matrix_t::Identity(2,3)))));
+  solver.add (impl);
+  // Test inclusion of manifolds
+  solver1.add (impl->copy ());
+  BOOST_CHECK (solver.definesSubmanifoldOf (solver));
+  BOOST_CHECK (solver.definesSubmanifoldOf (solver1));
+  BOOST_CHECK (solver1.definesSubmanifoldOf (solver));
+
   // q1 = g(q3)
   Eigen::Matrix<value_type,1,1> Jg; Jg (0,0) = 1;
   Eigen::RowBlockIndices inArg; inArg.addRow (2,1);
@@ -563,6 +573,9 @@ BOOST_AUTO_TEST_CASE(functions1)
   ExplicitPtr_t expl (Explicit::create (LiegroupSpace::R3 (),affine ,
                                         in, out, in, out));
   solver.add(expl);
+  // Test inclusion of manifolds
+  BOOST_CHECK (solver.definesSubmanifoldOf (solver1));
+  solver1.add (expl->copy ());
   // q2 = C
   affine = AffineFunctionPtr_t (new AffineFunction
                                 (matrix_t(1,0), vector_t::Zero(1)));
@@ -572,12 +585,14 @@ BOOST_AUTO_TEST_CASE(functions1)
                            in, out, in, out);
   solver.add(expl);
   BOOST_CHECK_EQUAL(solver.reducedDimension(), 2);
+  BOOST_CHECK (solver.definesSubmanifoldOf (solver1));
 
   // h
   matrix_t h (1,3); h << 0, 1, 0;
   solver.add(Implicit::create (AffineFunctionPtr_t(new AffineFunction (h))));
   BOOST_CHECK_EQUAL(solver.       dimension(), 3);
   BOOST_CHECK_EQUAL(solver.reducedDimension(), 2);
+  BOOST_CHECK (solver.definesSubmanifoldOf (solver1));
 
   segments_t impDof = list_of(segment_t(2,1));
   BOOST_CHECK_EQUAL(solver.implicitDof(), impDof);


### PR DESCRIPTION
Method HierarchicalIterative::definesSubmanifold test whether the solution manifold of a solver is a submanifold of the solution manifold of another solver.

Somes tests have been added in tests/solver-by-substitution.