### PR TITLE
explicit cast template arguments, fix #90

### DIFF
--- a/src/generic-transformation.cc
+++ b/src/generic-transformation.cc
@@ -159,11 +159,11 @@ namespace hpp {
       (const std::string& name, const DevicePtr_t& robot,
        std::vector <bool> mask) :
         DifferentiableFunction (robot->configSize (), robot->numberDof (),
-            liegroupSpace <ComputePosition, ComputeOrientation, OutputSE3> (mask),
+            liegroupSpace <(bool)ComputePosition, (bool)ComputeOrientation, (bool)OutputSE3> (mask),
             name),
         robot_ (robot),
         m_(robot->numberDof()-robot->extraConfigSpace().dimension()),
-        Vindices_ (indices<ComputePosition, ComputeOrientation, OutputSE3> (mask)),
+        Vindices_ (indices<(bool)ComputePosition, (bool)ComputeOrientation, (bool)OutputSE3> (mask)),
         mask_ (mask)
     {
       assert(mask.size()==DerSize);

--- a/tests/convex-shape.cc
+++ b/tests/convex-shape.cc
@@ -15,6 +15,9 @@
 // hpp-constraints. If not, see <http://www.gnu.org/licenses/>.
 
 #define BOOST_TEST_MODULE ConvexShape
+
+#include <pinocchio/fwd.hpp>
+
 #include <boost/test/included/unit_test.hpp>
 
 #include "hpp/constraints/convex-shape.hh"

--- a/tests/multithread.cc
+++ b/tests/multithread.cc
@@ -15,6 +15,9 @@
 // hpp-constraints. If not, see <http://www.gnu.org/licenses/>.
 
 #define BOOST_TEST_MODULE multithread_test
+
+#include <pinocchio/fwd.hpp>
+
 #include <boost/test/included/unit_test.hpp>
 
 #include <stdlib.h>

--- a/tests/symbolic-calculus.cc
+++ b/tests/symbolic-calculus.cc
@@ -15,6 +15,9 @@
 // hpp-constraints. If not, see <http://www.gnu.org/licenses/>.
 
 #define BOOST_TEST_MODULE SymbolicCalculus
+
+#include <pinocchio/fwd.hpp>
+
 #include <boost/test/included/unit_test.hpp>
 
 #include <stdlib.h>


### PR DESCRIPTION
FTR, I also had to add `-Wno-c++11-narrowing` for clang 8 or `-Wno-narrowing` for GCC 9

While here, fix usual issues with https://github.com/stack-of-tasks/pinocchio/issues/849