### PR TITLE
include pinocchio before boost

### DIFF
--- a/tests/convex-shape.cc
+++ b/tests/convex-shape.cc
@@ -14,7 +14,6 @@
 // received a copy of the GNU Lesser General Public License along with
 // hpp-constraints. If not, see <http://www.gnu.org/licenses/>.
 
-#include <pinocchio/fwd.hpp>
 #define BOOST_TEST_MODULE ConvexShape
 
 #include <pinocchio/fwd.hpp>

--- a/tests/logarithm.cc
+++ b/tests/logarithm.cc
@@ -15,6 +15,7 @@
 // hpp-constraints. If not, see <http://www.gnu.org/licenses/>.
 
 #define BOOST_TEST_MODULE hpp_constraints
+#include <pinocchio/fwd.hpp>
 #include <boost/test/included/unit_test.hpp>
 
 #include <pinocchio/spatial/explog.hpp>

--- a/tests/multithread.cc
+++ b/tests/multithread.cc
@@ -14,8 +14,6 @@
 // received a copy of the GNU Lesser General Public License along with
 // hpp-constraints. If not, see <http://www.gnu.org/licenses/>.
 
-#include <pinocchio/fwd.hpp>
-
 #define BOOST_TEST_MODULE multithread_test
 
 #include <pinocchio/fwd.hpp>

--- a/tests/symbolic-calculus.cc
+++ b/tests/symbolic-calculus.cc
@@ -14,8 +14,6 @@
 // received a copy of the GNU Lesser General Public License along with
 // hpp-constraints. If not, see <http://www.gnu.org/licenses/>.
 
-#include <pinocchio/fwd.hpp>
-
 #define BOOST_TEST_MODULE SymbolicCalculus
 
 #include <pinocchio/fwd.hpp>
@@ -45,7 +43,7 @@ class PointTesterT : public CalculusBase <PointTesterT<ValueType, JacobianType>,
     struct DataWrapper {
       ValueType value;
       JacobianType jacobian;
-      
+
       EIGEN_MAKE_ALIGNED_OPERATOR_NEW
     };
 


### PR DESCRIPTION
ref https://github.com/stack-of-tasks/pinocchio/issues/849

This was already adressed in both #94 and #96, so the header was added
twice in some files, but one was still missing.