### PR TITLE
fix tests in hpp-wholebody-step

### DIFF
--- a/include/hpp/constraints/solver/impl/by-substitution.hh
+++ b/include/hpp/constraints/solver/impl/by-substitution.hh
@@ -118,7 +118,7 @@ namespace hpp {
           } else {
             dq_ /= scaling;
             scaling *= 0.5;
-            arg = qopt;
+            if (qopt.size() > 0) arg = qopt;
             onlyLineSearch = true;
           }
         }


### PR DESCRIPTION
Hi,

In the test of hpp-wholebody-step, at some point, on this line, and on my system (18.04), `qopt` is of size 0.
Considering the line 137: ` if (optimize && qopt.size() > 0) arg = qopt;`, I suggest to add this check, which fix the tests in my use case (without breaking the tests of hpp-constraints), but I actually have no idea what I'm doing :)