### PR TITLE
[ExplicitConstraintSet] Fix computation of right hand side

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,19 @@
                                                                 -*- outline -*-
+New in ...
+* Computation of constraint right hand side have been fixed
+  - in ExplicitConstraintSet, the computation was wrong, it has been fixed,
+  - in Implicit, the computation has been made similar to the one in
+    HierarchicalIterative.
+* Template flag definitions in GenericTransformation have been fixed
+  - to comply with C++11 standard.
+* throw declaration have been removed to comply with C++11 standard.
+* Configuration variable RUN_TESTS has benn replaced by BUILD_TESTING
+  - for homogeneity with other hpp packages.
+
+New in 4.8.0
+* Wrong indentation in output stream has been fixed.
+
+New in 4.7.0
 * Class HierarchicalIterative
   - a bug in right hand side getter by constraint has been fixed,
   - a getter to numerical constraints has been added. It returns the implicit

--- a/doc/main-page.hh
+++ b/doc/main-page.hh
@@ -1,24 +1,45 @@
-namespace hpp {
-  namespace constraints {
-    /// \mainpage
-    /// \anchor hpp_constraints_documentation
-    ///
-    /// This package provides a representation of the concept of mathematical
-    /// functions from a manifold, for instace the configuration space of a robot
-    /// (hpp::pinocchio::Device) to a finite dimensional vector space.<BR>
-    ///
-    /// Some robots can be subject to constraints.
-    /// \li closed kinematic chains,
-    /// \li quasi-static equilibrium for legged robots
-    ///
-    /// are examples of such constraints. These constraints can be defined
-    /// implicitely by an equation the left hand side of which is a \ref
-    /// DifferentiableFunction "differentiable function" of the
-    /// robot configuration.
-    ///
-    /// \defgroup constraints Constraints
-    /// \defgroup solvers Constraint solvers
-    /// \defgroup hpp_constraints_tools Tools
-    /// \ingroup constraints
-  } // namespace constraints
-} // namespace hpp
+/// \mainpage
+/// \anchor hpp_constraints_documentation
+///
+/// \section hpp_constraints_concepts Mathematical Concepts
+///
+/// This package provides a representation of the following mathematical
+/// concepts:
+/// \li \link hpp::constraints::DifferentiableFunction differentiable
+/// functions\endlink from a \link hpp::pinocchio::LiegroupSpace Lie
+/// group\endlink, for instance the configuration space of a robot
+/// (hpp::pinocchio::Device) to a another \link
+/// hpp::pinocchio::LiegroupSpace Lie group\endlink;
+/// \li \link hpp::constraints::Implicit implicit constraints\endlink
+/// are composed of a left hand side that is a differentiable
+/// function, a \link hpp::constraints::ComparisonTypes_t comparison
+/// vector\endlink, and a right hand side;
+/// \li \link hpp::constraints::Explicit explicit constraints\endlink are
+/// numerical constraints that can be solved by computing some input
+/// variables with respect to others.
+///
+/// \section hpp_constraints_solvers Numerical Solvers
+///
+/// The constraints defined in the previous section can be solved by some
+/// numerical solvers.
+/// \li \link hpp::constraints::solver::HierarchicalIterative
+/// HierarchicalIterative \endlink solves a set of implicit constraints with
+/// priority order following a Newton like iterative procedure.
+/// \li \link hpp::constraints::solver::BySubstitution BySubstitution \endlink
+/// derives from the former and substitutes output variables of explicit
+/// constraints with their explicit expression, solving numerically over the
+/// remaining variables.
+/// \li Compatible explicit constraints are gathered into \link
+/// hpp::constraints::ExplicitConstraintSet ExplicitConstraintSet\endlink and
+/// used by BySubstitution solver.
+///
+/// One of the most common use cases of explicit constraint is the
+/// \link hpp::constraints::explicit_::RelativePose relative pose\endlink
+/// constraint where a free floating object is hold by a robot gripper. In
+/// this case, the configuration variables of the object can be explicitely
+/// expressed with respect to the robot configuration variables.
+///
+/// \defgroup constraints Constraints
+/// \defgroup solvers Constraint solvers
+/// \defgroup hpp_constraints_tools Tools
+/// \ingroup constraints

--- a/include/hpp/constraints/differentiable-function.hh
+++ b/include/hpp/constraints/differentiable-function.hh
@@ -29,7 +29,24 @@ namespace hpp {
     /// \addtogroup constraints
     /// \{
 
-    /// Differentiable function
+    /// Differentiable function from a \link hpp::pinocchio::LiegroupSpace Lie
+    /// group\endlink, for instance the configuration space of a robot
+    /// (hpp::pinocchio::Device) to a another \link
+    /// hpp::pinocchio::LiegroupSpace Lie group\endlink.
+    ///
+    /// Note that the input Lie group is only represented by the sizes
+    /// of the elements and of the velocities: methods \link
+    /// DifferentiableFunction::inputSize inputSize\endlink and \link
+    /// DifferentiableFunction::inputDerivativeSize
+    /// inputDerivativeSize\endlink
+    ///
+    /// The output space can be accessed by method \link
+    /// DifferentiableFunction::outputSpace outputSpace\endlink.
+    ///
+    /// The value of the function for a given input can be accessed by method
+    /// \link DifferentiableFunction::value value \endlink.
+    /// The Jacobian of the function for a given input can be accessed by
+    /// method \link DifferentiableFunction::jacobian jacobian \endlink.
     class HPP_CONSTRAINTS_DLLAPI DifferentiableFunction
     {
     public:
@@ -94,10 +111,7 @@ namespace hpp {
       {
 	return inputDerivativeSize_;
       }
-      /// Get output element
-      ///
-      /// Getting an output element enables users to know the type of Liegroup
-      /// the function output values lie in.
+      /// Get output space
       LiegroupSpacePtr_t outputSpace () const
       {
         return outputSpace_;

--- a/include/hpp/constraints/explicit.hh
+++ b/include/hpp/constraints/explicit.hh
@@ -226,6 +226,24 @@ namespace hpp {
         explicitRhs = implicitRhs;
       }
 
+      /// Convert right hand side
+      ///
+      /// \param explicitRhs right hand side of explicit formulation.
+      /// \retval implicitRhs right hand side of implicit formulation,
+      ///
+      /// When implicit formulation is different from explicit formulation,
+      ///\sa hpp::constraints::explicit_::RelativePose, right hand side are
+      /// also different. This method converts right hand side from explicit
+      /// to implicit formulation.
+      ///
+      /// When implicit formulation derives from explicit one, this method
+      /// copies the first argument to the second one.
+      virtual void explicitToImplicitRhs (vectorIn_t explicitRhs,
+                                          vectorOut_t implicitRhs) const
+      {
+        implicitRhs = explicitRhs;
+      }
+
     protected:
       /// Constructor
       ///

--- a/include/hpp/constraints/explicit.hh
+++ b/include/hpp/constraints/explicit.hh
@@ -221,7 +221,7 @@ namespace hpp {
       /// When implicit formulation derives from explicit one, this method
       /// copies the first argument to the second one.
       virtual void implicitToExplicitRhs (vectorIn_t implicitRhs,
-                                          vectorOut_t explicitRhs)
+                                          vectorOut_t explicitRhs) const
       {
         explicitRhs = implicitRhs;
       }

--- a/include/hpp/constraints/explicit/relative-pose.hh
+++ b/include/hpp/constraints/explicit/relative-pose.hh
@@ -77,6 +77,28 @@ namespace hpp {
         */
         virtual void implicitToExplicitRhs (vectorIn_t implicitRhs,
                                             vectorOut_t explicitRhs) const;
+        /** Convert right hand side
+
+            \param explicitRhs right hand side of explicit formulation,
+            \retval implicitRhs right hand side of implicit formulation.
+
+            For this constraint, the implicit formulation does not derive
+            from  the explicit formulation. The explicit form writes
+
+            \f{eqnarray}
+            rhs_{expl} &=& \log_{SE(3)} \left(F_{2/J_2} F_{1/J_1}^{-1} J_1^{-1}
+            J_2\right)\\
+            rhs_{impl} &=& \log_{\mathbf{R}^3\times SO(3)} \left(F_{1/J_1}^{-1}
+            J_1^{-1}J_2 F_{2/J_2}\right)
+            \f}
+            Thus
+            \f{equation}
+            rhs_{impl} = \log_{\mathbf{R}^3\times SO(3)}\left( F_{2/J_2}^{-1}
+            \exp_{SE(3)} (rhs_{expl})  F_{2/J_2}\right)
+            \f}
+        */
+        virtual void explicitToImplicitRhs (vectorIn_t explicitRhs,
+                                            vectorOut_t implicitRhs) const;
       protected:
         /// Constructor
         ///

--- a/include/hpp/constraints/explicit/relative-pose.hh
+++ b/include/hpp/constraints/explicit/relative-pose.hh
@@ -75,9 +75,8 @@ namespace hpp {
             SO(3)} (rhs_{impl})  F_{2/J_2}^{-1}\right)
             \f}
         */
-
         virtual void implicitToExplicitRhs (vectorIn_t implicitRhs,
-                                            vectorOut_t explicitRhs);
+                                            vectorOut_t explicitRhs) const;
       protected:
         /// Constructor
         ///

--- a/src/explicit-constraint-set.cc
+++ b/src/explicit-constraint-set.cc
@@ -346,18 +346,12 @@ namespace hpp {
     (const size_type& i, vectorIn_t arg)
     {
       Data& d = data_[i];
-      d.qin = RowBlockIndices (d.constraint->inputConf ()).rview(arg);
-      d.constraint->explicitFunction ()->value(d.f_value, d.qin);
-      d.qout = RowBlockIndices (d.constraint->outputConf ()).rview(arg);
-      d.res_qout.vector() = d.qout;
-      vector_t rhs = d.res_qout - d.f_value;
-      d.equalityIndices.lview(d.rhs_explicit) = d.equalityIndices.rview(rhs);
-
       // compute right hand side of implicit formulation that might be
       // different (RelativePose)
       d.constraint->function ().value (d.h_value, arg);
-      rhs = d.h_value.vector ();
+      vector_t rhs = d.h_value.vector ();
       d.equalityIndices.lview(d.rhs_implicit) = d.equalityIndices.rview(rhs);
+      d.constraint->implicitToExplicitRhs(d.rhs_implicit, d.rhs_explicit);
     }
 
     void ExplicitConstraintSet::rightHandSide (vectorIn_t rhs)

--- a/src/explicit/relative-pose.cc
+++ b/src/explicit/relative-pose.cc
@@ -140,7 +140,7 @@ namespace hpp {
       }
 
       void RelativePose::implicitToExplicitRhs (vectorIn_t implicitRhs,
-                                                vectorOut_t explicitRhs)
+                                                vectorOut_t explicitRhs) const
       {
         assert (implicitRhs.size () == 6);
         assert (explicitRhs.size () == 6);


### PR DESCRIPTION
  - Computation of right hand side was wrong, especially when the ExplicitConstraintSet included a
    RelativePose with comparison type Equal at rank 3 (rotation around x).
  - a test has been added.
  - the new version has been successfully tested with benchmark romeo-placard and with a new
    benchmark.