### PR TITLE
Refactor Implicit initialization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ SET(${PROJECT_NAME}_HEADERS
   include/hpp/constraints/differentiable-function-set.hh
   include/hpp/constraints/active-set-differentiable-function.hh
   include/hpp/constraints/affine-function.hh
+  include/hpp/constraints/comparison-types.hh
   include/hpp/constraints/distance-between-bodies.hh
   include/hpp/constraints/fwd.hh
   include/hpp/constraints/svd.hh

--- a/include/hpp/constraints/comparison-types.hh
+++ b/include/hpp/constraints/comparison-types.hh
@@ -1,0 +1,165 @@
+// Copyright (c) 2020 CNRS, Airbus SAS
+// Author: Florent Lamiraux
+// Authors: Joseph Mirabel (joseph.mirabel@laas.fr), Florent Lamiraux
+//
+// This file is part of hpp-constraints.
+// hpp-constraints is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+//
+// hpp-constraints is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Lesser Public License for more details.  You should have
+// received a copy of the GNU Lesser General Public License along with
+// hpp-constraints. If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef HPP_CONSTRAINTS_COMOARISON_TYPES_HH
+#define HPP_CONSTRAINTS_COMOARISON_TYPES_HH
+
+#include <iostream>
+#include <vector>
+#include <hpp/constraints/fwd.hh>
+
+namespace hpp {
+  namespace constraints {
+    namespace internal {
+      /// \cond HIDDEN_SYMBOLS
+      struct ReplicateCompType {
+        ComparisonType type;
+        std::size_t n;
+
+        void push_to(ComparisonTypes_t& v) const
+        {
+          for (std::size_t i = 0; i < n; ++i) v.push_back(type);
+        }
+        // Cast to ComparisonTypes_t
+        operator ComparisonTypes_t() const
+        {
+          return ComparisonTypes_t(n, type);
+        }
+      }; // struct ReplicateCompType
+      /// \endcond
+    }
+    inline internal::ReplicateCompType operator*(const int& n,
+                                                 const ComparisonType& c)
+    {
+      internal::ReplicateCompType cts;
+      cts.type = c;
+      cts.n = (std::size_t)n;
+      return cts;
+    }
+
+    inline ComparisonTypes_t operator<<(const ComparisonType& a,
+                                        const ComparisonType& b)
+    {
+      ComparisonTypes_t v(2);
+      v[0]=a;
+      v[1]=b;
+      return v;
+    }
+
+    inline ComparisonTypes_t operator<<(const internal::ReplicateCompType& a,
+                                        const ComparisonType& b)
+    {
+      ComparisonTypes_t v;
+      v.reserve(a.n+1);
+      a.push_to(v);
+      v.push_back(b);
+      return v;
+    }
+
+    inline ComparisonTypes_t operator<<(const ComparisonType& a,
+                                        const internal::ReplicateCompType& b)
+    {
+      ComparisonTypes_t v;
+      v.reserve(b.n+1);
+      v.push_back(a);
+      b.push_to(v);
+      return v;
+    }
+
+    inline ComparisonTypes_t& operator<<(ComparisonTypes_t& v,
+                                         const ComparisonType& c)
+    {
+      v.push_back(c);
+      return v;
+    }
+
+    inline ComparisonTypes_t& operator<<(ComparisonTypes_t& v,
+                                         const internal::ReplicateCompType& c)
+    {
+      for (std::size_t i = 0; i < c.n; ++i) v.push_back(c.type);
+      return v;
+    }
+
+    inline ComparisonTypes_t operator<<(const ComparisonTypes_t& v,
+                                        const ComparisonType& c)
+    {
+      ComparisonTypes_t vv;
+      vv.reserve(v.size()+1);
+      vv.insert(vv.end(), v.begin(), v.end());
+      vv.push_back(c);
+      return vv;
+    }
+
+    inline ComparisonTypes_t operator<<(const ComparisonTypes_t& v,
+                                        const internal::ReplicateCompType& c)
+    {
+      ComparisonTypes_t vv;
+      vv.reserve(v.size()+c.n);
+      vv.insert(vv.end(), v.begin(), v.end());
+      for (std::size_t i = 0; i < c.n; ++i) vv.push_back(c.type);
+      return vv;
+    }
+
+    inline bool operator==(const ComparisonTypes_t& v,
+                           const internal::ReplicateCompType& r)
+    {
+      if (v.size() != r.n) return false;
+      for (std::size_t i=0; i<v.size(); ++i)
+      {
+        if (v[i] != r.type) return false;
+      }
+      return true;
+    }
+
+    inline std::ostream& operator<<(std::ostream& os,
+                                    const ComparisonTypes_t& comp)
+    {
+      os << "(";
+      for (ComparisonTypes_t::const_iterator it=comp.begin();
+           it!=comp.end(); ++it)
+      {
+        if (*it == Equality) {
+          os << "Equality";
+        } else if (*it == EqualToZero) {
+          os << "EqualToZero";
+        } else if (*it == Superior) {
+          os << "Superior";
+        } else if (*it == Inferior) {
+          os << "Inferior";
+        } else {
+          assert("false && ComparisonType out of range.");
+        }
+        if(it+1 != comp.end())
+          os << ", ";
+      }
+      os << ")";
+      return os;
+    }
+  } // namespace constraints
+} // namespace hpp
+
+inline hpp::constraints::ComparisonTypes_t operator<<
+(hpp::constraints::internal::ReplicateCompType c1,
+ hpp::constraints::internal::ReplicateCompType c2)
+{
+  hpp::constraints::ComparisonTypes_t vv(c1);
+  for (std::size_t i = 0; i < c2.n; ++i) vv.push_back(c2.type);
+  return vv;
+}
+
+
+#endif // HPP_CONSTRAINTS_COMOARISON_TYPES_HH

--- a/include/hpp/constraints/explicit/relative-pose.hh
+++ b/include/hpp/constraints/explicit/relative-pose.hh
@@ -48,8 +48,7 @@ namespace hpp {
           (const std::string& name, const DevicePtr_t& robot,
            const JointConstPtr_t& joint1, const JointConstPtr_t& joint2,
            const Transform3f& frame1, const Transform3f& frame2,
-           std::vector <bool> mask = std::vector<bool>(6,true),
-           ComparisonTypes_t comp = std::vector <ComparisonType>());
+           ComparisonTypes_t comp);
 
         static RelativePosePtr_t createCopy (const RelativePosePtr_t& other);
 
@@ -102,7 +101,7 @@ namespace hpp {
                       const JointConstPtr_t& joint2,
                       const Transform3f& frame1, const Transform3f& frame2,
                       std::vector <bool> mask = std::vector<bool>(6,true),
-                      ComparisonTypes_t comp = std::vector <ComparisonType> ());
+                      ComparisonTypes_t comp = ComparisonTypes_t());
 
         /// Copy constructor
         RelativePose (const RelativePose& other);

--- a/include/hpp/constraints/fwd.hh
+++ b/include/hpp/constraints/fwd.hh
@@ -130,13 +130,6 @@ namespace hpp {
     typedef boost::shared_ptr<AffineFunction> AffineFunctionPtr_t;
     typedef boost::shared_ptr<ConstantFunction> ConstantFunctionPtr_t;
 
-    typedef HPP_CONSTRAINTS_DEPRECATED ConvexShapeContact StaticStabilityGravity;
-    typedef HPP_CONSTRAINTS_DEPRECATED ConvexShapeContactComplement StaticStabilityGravityComplement;
-    typedef HPP_CONSTRAINTS_DEPRECATED
-      ConvexShapeContactPtr_t StaticStabilityGravityPtr_t;
-    typedef HPP_CONSTRAINTS_DEPRECATED
-      ConvexShapeContactComplementPtr_t StaticStabilityGravityComplementPtr_t;
-
     template <int _Options> class GenericTransformation;
 
     /// \cond DEVEL
@@ -214,10 +207,6 @@ namespace hpp {
       HPP_PREDEF_CLASS (OfParameterSubset);
       typedef boost::shared_ptr <OfParameterSubset> OfParameterSubsetPtr_t;
     } // namespace function
-    typedef ExplicitConstraintSet ExplicitSolver HPP_CONSTRAINTS_DEPRECATED;
-    typedef solver::HierarchicalIterative HierarchicalIterativeSolver
-    HPP_CONSTRAINTS_DEPRECATED;
-    typedef solver::BySubstitution HybridSolver HPP_CONSTRAINTS_DEPRECATED;
   } // namespace constraints
 } // namespace hpp
 

--- a/include/hpp/constraints/implicit-constraint-set.hh
+++ b/include/hpp/constraints/implicit-constraint-set.hh
@@ -62,16 +62,13 @@ namespace hpp {
           // Handle comparison types
           const ComparisonTypes_t& comp (constraint->comparisonType ());
           for (std::size_t i = 0; i < comp.size(); ++i) {
-            switch (comp[i]) {
-            case Superior:
-            case Inferior:
+            if ((comp[i] == Superior) && (comp[i] == Inferior))
+            {
               inequalityIndices_.push_back (comparison_.size());
-              break;
-            case Equality:
+            }
+            else if (comp[i] == Equality)
+            {
               equalityIndices_.addRow(comparison_.size(), 1);
-              break;
-            default:
-              break;
             }
             comparison_.push_back (comp[i]);
           }

--- a/include/hpp/constraints/implicit.hh
+++ b/include/hpp/constraints/implicit.hh
@@ -20,6 +20,7 @@
 
 # include <hpp/constraints/fwd.hh>
 # include <hpp/constraints/config.hh>
+# include <hpp/constraints/comparison-types.hh>
 
 # include <hpp/util/serialization-fwd.hh>
 
@@ -106,8 +107,9 @@ namespace hpp {
         virtual ImplicitPtr_t copy () const;
         /// Create a shared pointer to a new instance.
         /// \sa constructors
-        static ImplicitPtr_t create
-          (const DifferentiableFunctionPtr_t& function);
+        /// \deprecated Use method with comparison types
+        static ImplicitPtr_t create(const DifferentiableFunctionPtr_t& function)
+          HPP_CONSTRAINTS_DEPRECATED;
 
         /// Create a shared pointer to a new instance.
         /// \sa constructors
@@ -134,7 +136,7 @@ namespace hpp {
         /// constraints
         /// \param config the input configuration.
         ///
-        /// \warning Only values of the right hand side corresponding to 
+        /// \warning Only values of the right hand side corresponding to
         /// \link Equality "equality constraints" \endlink are set. As a
         /// result, the input configuration may not satisfy the other
         /// constraints.

--- a/include/hpp/constraints/solver/by-substitution.hh
+++ b/include/hpp/constraints/solver/by-substitution.hh
@@ -88,21 +88,6 @@ namespace hpp {
           return add (numericalConstraint, priority);
         }
 
-        /// Add an implicit constraint
-        ///
-        /// \param f differentiable function from the robot configuration space
-        ///          to a Lie group (See hpp::pinocchio::LiegroupSpace),
-        /// \param priority level of priority of the constraint: priority are
-        ///        in decreasing order: 0 is the highest priority level,
-        /// \param comp comparison type. See class documentation for details.
-        ///
-        /// \deprecated Use bool BySubstitution::add (const
-        ///          ImplicitPtr_t& numericalConstraint, const
-        ///          std::size_t priority = 0) instead.
-        void add (const DifferentiableFunctionPtr_t& f,
-                  const std::size_t& priority,
-                  const ComparisonTypes_t& comp) HPP_CONSTRAINTS_DEPRECATED;
-
         /// Get the numerical constraints implicit and explicit
         const NumericalConstraints_t& numericalConstraints () const
         {

--- a/src/explicit-constraint-set.cc
+++ b/src/explicit-constraint-set.cc
@@ -134,14 +134,8 @@ namespace hpp {
       jacobian.resize(_constraint->explicitFunction ()->outputDerivativeSize(),
                       _constraint->explicitFunction ()->inputDerivativeSize());
       for (std::size_t i = 0; i < constraint->comparisonType ().size(); ++i) {
-        switch (constraint->comparisonType ()[i]) {
-          case Equality:
-            equalityIndices.addRow(i, 1);
-            break;
-          case Superior:
-          case Inferior:
-          default:
-            break;
+        if (constraint->comparisonType ()[i] == Equality) {
+          equalityIndices.addRow(i, 1);
         }
       }
       equalityIndices.updateRows<true, true, true>();

--- a/src/explicit/convex-shape-contact.cc
+++ b/src/explicit/convex-shape-contact.cc
@@ -56,11 +56,11 @@ namespace hpp {
                     (name, robot, floorSurfaces, objectSurfaces));
         functions.first->setNormalMargin(margin);
         // Contact constraint (= 0)
-        std::get<0>(result) = Implicit::create(functions.first);
+        std::get<0>(result) = Implicit::create(functions.first, 5*EqualToZero);
         // Contact constraint complement (= rhs)
-        std::get<1>(result) = Implicit::create(functions.second,
-          ComparisonTypes_t(functions.second->outputSize(),
-                            constraints::Equality));
+        std::get<1>(result) = Implicit::create
+          (functions.second, ComparisonTypes_t(functions.second->outputSize(),
+            constraints::Equality));
         std::get<2>(result) = create(name + "/hold", robot, floorSurfaces,
                                      objectSurfaces, margin);
         return result;
@@ -144,8 +144,7 @@ namespace hpp {
                  contact::inputVelocityVariables
                  (robot, floorSurfaces, objectSurfaces),
                  relativePose::jointVelInterval(objectSurfaces.front().first),
-                 list_of(EqualToZero)(EqualToZero)(EqualToZero)(EqualToZero)
-                 (EqualToZero)(Equality)(Equality)(Equality))
+                 (5 * EqualToZero << 3 * Equality))
       {
         assert(HPP_DYNAMIC_PTR_CAST(ConvexShapeContactHold, functionPtr()));
         ConvexShapeContactHoldPtr_t f
@@ -166,9 +165,12 @@ namespace hpp {
           hppDout(info, "posInJoint" << posInJoint);
           for (std::size_t i=0; i<os.size(); ++i)
           {
+            // Create explicit relative pose for each combination
+            // (floor surface, object surface)
             pose_.push_back(RelativePose::create
                             ("",robot, fs[j].joint_, os[i].joint_,
-                             posInJoint, os[i].positionInJoint()));
+                             posInJoint, os[i].positionInJoint(),
+                             6 * Equality));
           }
         }
       }

--- a/src/explicit/relative-pose.cc
+++ b/src/explicit/relative-pose.cc
@@ -33,11 +33,11 @@ namespace hpp {
         (const std::string& name, const DevicePtr_t& robot,
          const JointConstPtr_t& joint1, const JointConstPtr_t& joint2,
          const Transform3f& frame1, const Transform3f& frame2,
-         std::vector <bool> mask, ComparisonTypes_t comp)
+         ComparisonTypes_t comp)
       {
         RelativePose* ptr (new RelativePose
                            (name, robot, joint1, joint2, frame1, frame2,
-                            mask, comp));
+                            std::vector<bool>(6,true), comp));
         RelativePosePtr_t shPtr (ptr);
         RelativePoseWkPtr_t wkPtr (shPtr);
         ptr->init (wkPtr);

--- a/src/implicit.cc
+++ b/src/implicit.cc
@@ -31,15 +31,8 @@ namespace hpp {
     {
       size_type size = 0;
       for (std::size_t i = 0; i < comp.size(); ++i) {
-        switch (comp[i]) {
-        case Superior:
-        case Inferior:
-          break;
-        case Equality:
+        if (comp[i] == Equality) {
           ++size;
-          break;
-        default:
-          break;
         }
       }
       return size;
@@ -130,12 +123,11 @@ namespace hpp {
       parameterSize_ (computeParameterSize (comparison_)),
       function_ (function)
     {
-      if (comp.size () == 0) {
-        // Argument was probably not provided, set to Equality
-        comparison_ = ComparisonTypes_t (function->outputDerivativeSize (),
-                                         Equality);
-      }
-      assert (function_->outputDerivativeSize () == (size_type)comparison_.size ());
+      // This constructor used to set comparison types to Equality if an
+      // empty vector was given as input. Now you should provide the
+      // comparison type at construction.
+      assert
+        (function_->outputDerivativeSize () == (size_type)comparison_.size ());
     }
 
     Implicit::Implicit (const DifferentiableFunctionPtr_t& function,
@@ -145,14 +137,12 @@ namespace hpp {
       if (rhs_.size () == 0) {
         rhs_ = vector_t::Zero (function->outputSize ());
       }
-      if (comp.size () == 0) {
-        // Argument was probably not provided, set to Equality
-        comparison_ = ComparisonTypes_t (function->outputDerivativeSize (),
-                                         Equality);
-      }
+      // This constructor used to set comparison types to Equality if an
+      // empty vector was given as input. Now you should provide the
+      // comparison type at construction.
+      assert
+        (function_->outputDerivativeSize () == (size_type)comparison_.size ());
       parameterSize_ = computeParameterSize (comparison_);
-      assert (function_->outputDerivativeSize () ==
-              (size_type)comparison_.size ());
       assert (function->outputDerivativeSize () == (size_type) rhs_.size ());
     }
 
@@ -176,7 +166,8 @@ namespace hpp {
     ImplicitPtr_t Implicit::create (
         const DifferentiableFunctionPtr_t& function)
     {
-      ComparisonTypes_t comp (function->outputDerivativeSize(), constraints::EqualToZero);
+      ComparisonTypes_t comp
+        (function->outputDerivativeSize(), constraints::EqualToZero);
 
       Implicit* ptr = new Implicit (function, comp);
       ImplicitPtr_t shPtr (ptr);

--- a/src/locked-joint.cc
+++ b/src/locked-joint.cc
@@ -133,7 +133,7 @@ namespace hpp {
                 segments_t(), // input vel
                 list_of(segment_t (joint->rankInVelocity     (),
                                    joint->numberDof ())), // output vel
-                ComparisonTypes_t (joint->numberDof(), Equality)),
+                ComparisonTypes_t(joint->numberDof(), Equality)),
       jointName_ (joint->name ()),
       configSpace_ (joint->configurationSpace ())
     {

--- a/src/solver/by-substitution.cc
+++ b/src/solver/by-substitution.cc
@@ -106,13 +106,6 @@ namespace hpp {
         return true;
       }
 
-      void BySubstitution::add (const DifferentiableFunctionPtr_t& f,
-                                const std::size_t& priority,
-                                const ComparisonTypes_t& comp)
-      {
-        HierarchicalIterative::add (Implicit::create (f, comp), priority);
-      }
-
       void BySubstitution::explicitConstraintSetHasChanged()
       {
         // set free variables to indices that are not output of the explicit

--- a/src/solver/hierarchical-iterative.cc
+++ b/src/solver/hierarchical-iterative.cc
@@ -67,12 +67,13 @@ namespace hpp {
         {
           for (std::size_t i = 0; i < indices.size(); ++i) {
             const std::size_t j = indices[i];
-            switch (comparison[j]) {
-            case Superior: compare<true , ComputeJac>
-                (value[j], jacobian.row(j), thr); break;
-            case Inferior: compare<false, ComputeJac>
-                (value[j], jacobian.row(j), thr); break;
-            default: break;
+            if (comparison[j] == Superior)
+            {
+              compare<true , ComputeJac>(value[j], jacobian.row(j), thr);
+            }
+            else if (comparison[j] == Inferior)
+            {
+              compare<false, ComputeJac>(value[j], jacobian.row(j), thr);
             }
           }
         }
@@ -271,16 +272,13 @@ namespace hpp {
         // therefore be done after the previous lines.
         stacks_ [priority].add (constraint);
         for (std::size_t i = 0; i < comp.size(); ++i) {
-          switch (comp[i]) {
-          case Superior:
-          case Inferior:
+          if ((comp[i] == Superior) || (comp[i] == Inferior))
+          {
             d.inequalityIndices.push_back (d.comparison.size());
-            break;
-          case Equality:
+          }
+          else if (comp[i] == Equality)
+          {
             d.equalityIndices.addRow(d.comparison.size(), 1);
-            break;
-          default:
-            break;
           }
           d.comparison.push_back (comp[i]);
         }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,6 +37,7 @@ IF(OPENMP_FOUND)
   ADD_TESTCASE(multithread)
 ENDIF()
 
+ADD_TESTCASE(comparison-types)
 ADD_TESTCASE(logarithm)
 ADD_TESTCASE(matrix-view)
 ADD_TESTCASE(svd)

--- a/tests/comparison-types.cc
+++ b/tests/comparison-types.cc
@@ -1,0 +1,96 @@
+// Copyright (c) 2020, CNRS - Airbus SAS
+// Authors: Florent Lamiraux
+//
+// This file is part of hpp-constraints.
+// hpp-constraints is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+//
+// hpp-constraints is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Lesser Public License for more details.  You should have
+// received a copy of the GNU Lesser General Public License along with
+// hpp-constraints. If not, see <http://www.gnu.org/licenses/>.
+
+#include <hpp/pinocchio/liegroup-space.hh>
+#include <hpp/constraints/affine-function.hh>
+#include <hpp/constraints/implicit.hh>
+
+#define BOOST_TEST_MODULE ComparisonTypes
+#include <boost/test/included/unit_test.hpp>
+
+using hpp::constraints::Implicit;
+using hpp::constraints::ImplicitPtr_t;
+using hpp::constraints::DifferentiableFunctionPtr_t;
+using hpp::constraints::ComparisonType;
+using hpp::constraints::ComparisonTypes_t;
+using hpp::constraints::Equality;
+using hpp::constraints::EqualToZero;
+using hpp::constraints::Superior;
+using hpp::constraints::Inferior;
+using hpp::constraints::Identity;
+using hpp::pinocchio::LiegroupSpace;
+
+BOOST_AUTO_TEST_CASE (operators)
+//int main()
+{
+  // [Inferior]
+  ComparisonTypes_t expected, actual(1, Inferior);
+  expected.push_back(Inferior);
+  BOOST_CHECK_EQUAL(expected, actual);
+  // [Equality, EqualToZero]
+  expected.clear(); actual.clear();
+  expected.push_back(Equality);
+  expected.push_back(EqualToZero);
+  actual = ComparisonTypes_t(Equality << EqualToZero);
+  BOOST_CHECK_EQUAL(expected, actual);
+  BOOST_CHECK_EQUAL(expected, Equality << EqualToZero);
+
+  // [Equality, EqualToZero, Inferior]
+  expected.clear(); actual.clear();
+  expected.push_back(Equality);
+  expected.push_back(EqualToZero);
+  expected.push_back(Inferior);
+  actual = (Equality << EqualToZero << Inferior);
+  BOOST_CHECK_EQUAL(expected, actual);
+  BOOST_CHECK_EQUAL(expected, Equality << EqualToZero << Inferior);
+
+  // [Equality, EqualToZero, 4 * Inferior]
+  expected.clear(); actual.clear();
+  expected.push_back(Equality);
+  expected.push_back(EqualToZero);
+  expected.push_back(Inferior);
+  expected.push_back(Inferior);
+  expected.push_back(Inferior);
+  expected.push_back(Inferior);
+
+  actual = (Equality << EqualToZero << 4 * Inferior);
+  BOOST_CHECK_EQUAL(expected, actual);
+  BOOST_CHECK_EQUAL(expected, Equality << EqualToZero << 4 * Inferior);
+  // [EqualToZero, EqualToZero, EqualToZero, EqualToZero, EqualToZero,
+  //  Equality, Equality, Equality] -> ConvexShapeContact
+  expected.clear(); actual.clear();
+  expected.push_back(EqualToZero);
+  expected.push_back(EqualToZero);
+  expected.push_back(EqualToZero);
+  expected.push_back(EqualToZero);
+  expected.push_back(EqualToZero);
+  expected.push_back(Equality);
+  expected.push_back(Equality);
+  expected.push_back(Equality);
+
+  actual = (EqualToZero << EqualToZero << EqualToZero << EqualToZero
+            << EqualToZero << Equality << Equality << Equality);
+  BOOST_CHECK_EQUAL(expected, actual);
+  ImplicitPtr_t constraint(Implicit::create(Identity::create
+                                            (LiegroupSpace::Rn(8), "I8"),
+    EqualToZero << EqualToZero << EqualToZero << EqualToZero << EqualToZero
+    << Equality << Equality << Equality));
+  BOOST_CHECK_EQUAL(expected, constraint->comparisonType());
+  actual = ComparisonTypes_t(EqualToZero << EqualToZero << EqualToZero
+                             << EqualToZero << EqualToZero << Equality
+                             << Equality << Equality);
+  BOOST_CHECK_EQUAL(expected, actual);
+}

--- a/tests/explicit-constraint-set.cc
+++ b/tests/explicit-constraint-set.cc
@@ -79,6 +79,8 @@ using hpp::constraints::Equality;
 using hpp::constraints::ComparisonTypes_t;
 using hpp::constraints::LockedJoint;
 using hpp::constraints::LockedJointPtr_t;
+using hpp::constraints::EqualToZero;
+using hpp::constraints::Equality;
 
 namespace Eigen {
   namespace internal {
@@ -631,7 +633,8 @@ BOOST_AUTO_TEST_CASE(RelativePose)
   // explicit relative pose
   hpp::constraints::ExplicitPtr_t constraint
     (hpp::constraints::explicit_::RelativePose::create
-     ("explicit-relative-pose", device, joint1, joint2, frame1, frame2));
+     ("explicit-relative-pose", device, joint1, joint2, frame1, frame2,
+      6 * Equality));
   assert(constraint->inputConf().size() == 1);
   assert(constraint->inputConf()[0].first == 0);
   assert(constraint->inputConf()[0].second == 7);
@@ -642,13 +645,13 @@ BOOST_AUTO_TEST_CASE(RelativePose)
     for (size_type i=0; i<64; ++i) {
       vector_t q (q_rand);
       size_type m = 1;
-      hpp::constraints::ComparisonTypes_t comp(6);
+      hpp::constraints::ComparisonTypes_t comp(6 * EqualToZero);
       for (size_type j=0; j<6; ++j) {
         // m = 2^(j+1)
         if ((m & i) == 0) {
-          comp [j] = hpp::constraints::Equality;
+          comp [j] = Equality;
         } else {
-          comp [j] = hpp::constraints::EqualToZero;
+          comp [j] = EqualToZero;
         }
         m *= 2;
       }
@@ -667,7 +670,7 @@ BOOST_AUTO_TEST_CASE(RelativePose)
       constraint->function().value(rhs2_impl, q);
       std::cout << "            \t";
       for (size_type j=0; j < (size_type)comp.size(); ++j) {
-        std::cout << (comp[j] == hpp::constraints::Equality ? " = \t" :
+        std::cout << (comp[j] == Equality ? " = \t" :
                       " =0\t");
       }
       std::cout << std::endl;
@@ -677,9 +680,9 @@ BOOST_AUTO_TEST_CASE(RelativePose)
       // rhs2_impl [j] == 0 if comp[i] is EqualToZero
       // rhs2_impl [j] == rhs0_impl [j] if comp[i] is Equality
       for (size_type j=0; j<6; ++j){
-        BOOST_CHECK(((comp[j] == hpp::constraints::EqualToZero) &&
+        BOOST_CHECK(((comp[j] == EqualToZero) &&
                      (fabs(rhs2_impl.vector()[j]) < 1e-10))
-                    || ((comp[j] == hpp::constraints::Equality) &&
+                    || ((comp[j] == Equality) &&
                         (fabs(rhs2_impl.vector()[j] - rhs0_impl.vector()[j])
                          < 1e-10)));
       }

--- a/tests/solver-by-substitution.cc
+++ b/tests/solver-by-substitution.cc
@@ -1055,7 +1055,7 @@ BOOST_AUTO_TEST_CASE (merge)
   BOOST_CHECK (solver3.rightHandSideFromConfig (c3, q));
 
   // Check computation of errors by constraint
-  // order is c1 c3 c2
+  // order is c1 c2 c3
   vector_t error (solver3.errorSize ());
   vector_t error1 (c1->function ().outputSpace ()->nv ());
   vector_t error2 (c2->function ().outputSpace ()->nv ());

--- a/tests/solver-hierarchical-iterative.cc
+++ b/tests/solver-hierarchical-iterative.cc
@@ -89,7 +89,7 @@ struct test_quadratic : test_base <LineSearch>
     Quadratic::Ptr_t f (new Quadratic (A, -1));
 
     this->solver.add (Implicit::create
-                      (f, ComparisonTypes_t (f->outputDerivativeSize (),
+                      (f, ComparisonTypes_t(f->outputDerivativeSize (),
                                              Equality)), 0);
     BOOST_CHECK(this->solver.numberStacks() == 1);
   }
@@ -161,12 +161,15 @@ BOOST_AUTO_TEST_CASE(one_layer)
   Transform3f tf1 (ee1->currentTransformation ());
   Transform3f tf2 (ee2->currentTransformation ());
 
-  solver.add(Implicit::create
-             (Orientation::create ("Orientation", device, ee2, tf2),
-              ComparisonTypes_t (3, Equality)), 0);
-  solver.add(Implicit::create
-             (Position::create    ("Position"   , device, ee2, tf2),
-              ComparisonTypes_t (3, Equality)), 0);
+  ImplicitPtr_t constraint(Implicit::create
+                  (Orientation::create ("Orientation", device, ee2, tf2),
+                   3 * Equality));
+  BOOST_CHECK(constraint->comparisonType() == 3 * Equality);
+  solver.add(constraint, 0);
+  constraint = Implicit::create
+    (Position::create    ("Position"   , device, ee2, tf2), 3 * Equality);
+  BOOST_CHECK(constraint->comparisonType() == 3 * Equality);
+  solver.add(constraint, 0);
 
   BOOST_CHECK(solver.numberStacks() == 1);
 


### PR DESCRIPTION
- make comparison types required in constructors,
- provide operator<< to ease construction of ComparisonTypes_t.