### PR TITLE
Constraints in Lie group

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,6 @@
                                                                 -*- outline -*-
+* TransformationR3xSO3 and RelativeTransformationR3xSO3 return error values
+  is R3xSO3 LiegroupSpace.
 * Solvers now handle constraints with right hand sides in Lie groups.
 * A mask has been added to class Implicit to select which lines of the
   constraint should be taken into account (active rows).

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,7 @@
                                                                 -*- outline -*-
+* Solvers now handle constraints with right hand sides in Lie groups.
+* A mask has been added to class Implicit to select which lines of the
+  constraint should be taken into account (active rows).
 New in 4.10.0
 * ConvexShapeContact classes have been improved.
   - stable position of objects is now unique for any right hand side value of

--- a/include/hpp/constraints/convex-shape-contact.hh
+++ b/include/hpp/constraints/convex-shape-contact.hh
@@ -242,8 +242,8 @@ namespace hpp {
       ///         the relative pose constraint corresponding to contact of
       ///         surfaces ifloor with iobject.
       void computeRelativePoseRightHandSide
-        (vectorIn_t rhs, std::size_t& ifloor, std::size_t& iobject,
-         vectorOut_t relativePoseRhs) const;
+        (LiegroupElementConstRef rhs, std::size_t& ifloor, std::size_t& iobject,
+         LiegroupElementRef relativePoseRhs) const;
     protected:
       /// Constructor
       /// \param name name of the sibling ConvexShapeContact constraint,

--- a/include/hpp/constraints/explicit-constraint-set.hh
+++ b/include/hpp/constraints/explicit-constraint-set.hh
@@ -472,7 +472,7 @@ namespace hpp {
           Data (const ExplicitPtr_t& constraint);
           ExplicitPtr_t constraint;
           RowBlockIndices equalityIndices;
-          vector_t rhs_implicit;
+          LiegroupElement rhs_implicit;
           // implicit formulation
           mutable LiegroupElement h_value;
           // explicit formulation

--- a/include/hpp/constraints/explicit.hh
+++ b/include/hpp/constraints/explicit.hh
@@ -211,7 +211,7 @@ namespace hpp {
       /// f \left((q_{ic_{1}} \cdots q_{ic_{n_{ic}}})^T\right) + rhs
       /// \f}
       virtual void outputValue(LiegroupElementRef result, vectorIn_t qin,
-                               vectorIn_t rhs) const;
+                               LiegroupElementConstRef rhs) const;
 
       /// Compute Jacobian of output value
       ///
@@ -224,7 +224,7 @@ namespace hpp {
       ///        recomputation,
       /// \param rhs right hand side (of implicit formulation).
       virtual void jacobianOutputValue(vectorIn_t qin, LiegroupElementConstRef
-                                       f_value, vectorIn_t rhs,
+                                       f_value, LiegroupElementConstRef rhs,
                                        matrixOut_t jacobian) const;
     protected:
       /// Constructor

--- a/include/hpp/constraints/explicit.hh
+++ b/include/hpp/constraints/explicit.hh
@@ -162,7 +162,9 @@ namespace hpp {
       ///            \f$(iv_{1}, \cdots, iv_{n_{iv}})\f$.
       /// \param outputVelocity set of integer defining indices
       ///            \f$(ov_{1}, \cdots, ov_{n_{ov}})\f$.
-      /// \note comparison type for this constraint is always equality
+      /// \param mask mask defining which components of the error are
+      ///        taken into account to determine whether the constraint
+      ///        is satisfied (See parent class for details).
       static ExplicitPtr_t create
         (const LiegroupSpacePtr_t& configSpace,
          const DifferentiableFunctionPtr_t& function,
@@ -170,7 +172,8 @@ namespace hpp {
 	 const segments_t& outputConf,
 	 const segments_t& inputVelocity,
 	 const segments_t& outputVelocity,
-         const ComparisonTypes_t& comp = ComparisonTypes_t());
+         const ComparisonTypes_t& comp = ComparisonTypes_t(),
+	 std::vector<bool> mask = std::vector<bool>());
 
       /// Create a copy and return shared pointer
       static ExplicitPtr_t createCopy (const ExplicitPtr_t& other);
@@ -266,7 +269,9 @@ namespace hpp {
       ///            \f$(iv_{1}, \cdots, iv_{n_{iv}})\f$.
       /// \param outputVelocity set of integer defining indices
       ///            \f$(ov_{1}, \cdots, ov_{n_{ov}})\f$.
-      /// \note comparison type for this constraint is always equality
+      /// \param mask mask defining which components of the error are
+      ///        taken into account to determine whether the constraint
+      ///        is satisfied (See parent class for details).
       Explicit
 	(const LiegroupSpacePtr_t& configSpace,
          const DifferentiableFunctionPtr_t& function,
@@ -274,7 +279,8 @@ namespace hpp {
 	 const segments_t& outputConf,
 	 const segments_t& inputVelocity,
 	 const segments_t& outputVelocity,
-         const ComparisonTypes_t& comp);
+         const ComparisonTypes_t& comp,
+	 std::vector<bool> mask);
 
       /// \copydoc Explicit (const LiegroupSpacePtr_t&, const DifferentiableFunctionPtr_t&, const segments_t& inputConf, const segments_t& outputConf, const segments_t& inputVelocity, const segments_t&, const ComparisonTypes_t&);
       /// \param implicitFunction differentiable function of the implicit
@@ -289,7 +295,8 @@ namespace hpp {
 	 const segments_t& outputConf,
 	 const segments_t& inputVelocity,
 	 const segments_t& outputVelocity,
-         const ComparisonTypes_t& comp);
+         const ComparisonTypes_t& comp,
+	 std::vector<bool> mask);
 
       /// Copy constructor
       Explicit (const Explicit& other);

--- a/include/hpp/constraints/explicit.hh
+++ b/include/hpp/constraints/explicit.hh
@@ -123,33 +123,6 @@ namespace hpp {
 
       /// Create instance and return shared pointer
       ///
-      /// \param robot Robot for which the constraint is defined.
-      /// \param function relation between input configuration variables and
-      ///        output configuration variables,
-      /// \param inputConf set of integer intervals defining indices
-      ///            \f$(ic_{1}, \cdots, ic_{n_{ic}})\f$,
-      /// \param outputConf set of integer intervals defining indices
-      ///            \f$(oc_{1}, \cdots, oc_{n_{oc}})\f$,
-      /// \param inputVelocity set of integer defining indices
-      ///            \f$(iv_{1}, \cdots, iv_{n_{iv}})\f$.
-      /// \param outputVelocity set of integer defining indices
-      ///            \f$(ov_{1}, \cdots, ov_{n_{ov}})\f$.
-      /// \note comparison type for this constraint is always equality
-      /// \deprecated Call method that takes LiegroupSpacePtr_t instead of
-      ///             DevicePtr_t as input and used robot->configSpace () as
-      ///             argument.
-      static ExplicitPtr_t create
-        (const DevicePtr_t& robot,
-         const DifferentiableFunctionPtr_t& function,
-	 const segments_t& inputConf,
-	 const segments_t& outputConf,
-	 const segments_t& inputVelocity,
-	 const segments_t& outputVelocity,
-         const ComparisonTypes_t& comp = ComparisonTypes_t())
-        HPP_CONSTRAINTS_DEPRECATED;
-
-      /// Create instance and return shared pointer
-      ///
       /// \param configSpace Configuration space on which the constraint is
       ///        defined,
       /// \param function relation between input configuration variables and
@@ -230,31 +203,6 @@ namespace hpp {
                                        f_value, LiegroupElementConstRef rhs,
                                        matrixOut_t jacobian) const;
     protected:
-      /// Constructor
-      ///
-      /// \param robot Robot for which the constraint is defined.
-      /// \param function relation between input configuration variables and
-      ///        output configuration variables,
-      /// \param inputConf set of integer intervals defining indices
-      ///            \f$(ic_{1}, \cdots, ic_{n_{ic}})\f$,
-      /// \param outputConf set of integer intervals defining indices
-      ///            \f$(oc_{1}, \cdots, oc_{n_{oc}})\f$,
-      /// \param inputVelocity set of integer defining indices
-      ///            \f$(iv_{1}, \cdots, iv_{n_{iv}})\f$.
-      /// \param outputVelocity set of integer defining indices
-      ///            \f$(ov_{1}, \cdots, ov_{n_{ov}})\f$.
-      /// \note comparison type for this constraint is always equality
-      /// \deprecated Use constructor that takes LiegroupSpacePtr_t instead of
-      ///             DevicePtr_t as input and used robot->configSpace () as
-      ///             argument.
-      Explicit
-	(const DevicePtr_t& robot, const DifferentiableFunctionPtr_t& function,
-	 const segments_t& inputConf,
-	 const segments_t& outputConf,
-	 const segments_t& inputVelocity,
-	 const segments_t& outputVelocity,
-         const ComparisonTypes_t& comp) HPP_CONSTRAINTS_DEPRECATED;
-
       /// Constructor
       ///
       /// \param configSpace Configuration space on which the constraint is

--- a/include/hpp/constraints/explicit/convex-shape-contact.hh
+++ b/include/hpp/constraints/explicit/convex-shape-contact.hh
@@ -68,13 +68,13 @@ namespace hpp {
           (const ConvexShapeContactPtr_t& other);
         /// Compute the object pose with respect
         /// \param qin input configuration variables,
-        /// \param rhs right hand side of constraint
+        /// \param rhs right hand side of constraint (of implicit formulation).
         ///
         /// The right hand side contains the following information:
         /// \li which floor surface is in contact with with object surface,
         /// \li the relative position of those surfaces.
         virtual void outputValue(LiegroupElementRef result, vectorIn_t qin,
-                                 vectorIn_t rhs) const;
+                                 LiegroupElementConstRef rhs) const;
 
         /// Compute Jacobian of output value
         ///
@@ -88,7 +88,7 @@ namespace hpp {
         /// \param rhs right hand side (of implicit formulation).
         virtual void jacobianOutputValue
           (vectorIn_t qin, LiegroupElementConstRef f_value,
-           vectorIn_t rhs, matrixOut_t jacobian) const;
+           LiegroupElementConstRef rhs, matrixOut_t jacobian) const;
       protected:
         /// Constructor
         /// \param robot the robot holding the floor and object contact

--- a/include/hpp/constraints/explicit/relative-pose.hh
+++ b/include/hpp/constraints/explicit/relative-pose.hh
@@ -60,11 +60,11 @@ namespace hpp {
         /// where \f$rhs_{expl}\f$ is the explicit right hand side converted
         /// using the following expression:
         /// \f{equation}
-        /// rhs_{expl} = \log_{SE(3)}\left( F_{2/J_2}\exp_{\mathbf{R}^3\times
-        /// SO(3)} (rhs_{impl})  F_{2/J_2}^{-1}\right)
+        /// rhs_{expl} = \log_{SE(3)}\left( F_{2/J_2} rhs_{impl} F_{2/J_2}^{-1}
+	///              \right)
         /// \f}
         virtual void outputValue(LiegroupElementRef result, vectorIn_t qin,
-                                 vectorIn_t rhs) const;
+                                 LiegroupElementConstRef rhs) const;
 
         /// Compute Jacobian of output value
         ///
@@ -76,7 +76,7 @@ namespace hpp {
         /// \param f_value \f$f(\mathbf{q}_{in})\f$ to avoid recomputation,
         /// \param rhs right hand side (of implicit formulation).
         virtual void jacobianOutputValue(vectorIn_t qin, LiegroupElementConstRef
-                                         f_value, vectorIn_t rhs,
+                                         f_value, LiegroupElementConstRef rhs,
                                          matrixOut_t jacobian) const;
       protected:
         /// Constructor
@@ -106,8 +106,10 @@ namespace hpp {
       private:
         /** Convert right hand side
 
-            \param implicitRhs right hand side of implicit formulation,
-            \retval explicitRhs right hand side of explicit formulation.
+            \param implicitRhs right hand side of implicit formulation, this
+	           is an element of $SE(3)$
+            \retval explicitRhs right hand side of explicit formulation, this
+                    is an element of $\mathbf{R}^6$.
 
             For this constraint, the implicit formulation does not derive
             from  the explicit formulation. The explicit form writes
@@ -115,16 +117,15 @@ namespace hpp {
             \f{eqnarray}
             rhs_{expl} &=& \log_{SE(3)} \left(F_{2/J_2} F_{1/J_1}^{-1} J_1^{-1}
             J_2\right)\\
-            rhs_{impl} &=& \log_{\mathbf{R}^3\times SO(3)} \left(F_{1/J_1}^{-1}
-            J_1^{-1}J_2 F_{2/J_2}\right)
+            rhs_{impl} &=& F_{1/J_1}^{-1} J_1^{-1}J_2 F_{2/J_2}
             \f}
             Thus
             \f{equation}
-            rhs_{expl} = \log_{SE(3)}\left( F_{2/J_2}\exp_{\mathbf{R}^3\times
-            SO(3)} (rhs_{impl})  F_{2/J_2}^{-1}\right)
+            rhs_{expl} = \log_{SE(3)}\left( F_{2/J_2}rhs_{impl}
+            F_{2/J_2}^{-1}\right)
             \f}
         */
-        void implicitToExplicitRhs (vectorIn_t implicitRhs,
+        void implicitToExplicitRhs (LiegroupElementConstRef implicitRhs,
                                     vectorOut_t explicitRhs) const;
         /** Convert right hand side
 
@@ -137,17 +138,15 @@ namespace hpp {
             \f{eqnarray}
             rhs_{expl} &=& \log_{SE(3)} \left(F_{2/J_2} F_{1/J_1}^{-1} J_1^{-1}
             J_2\right)\\
-            rhs_{impl} &=& \log_{\mathbf{R}^3\times SO(3)} \left(F_{1/J_1}^{-1}
-            J_1^{-1}J_2 F_{2/J_2}\right)
+            rhs_{impl} &=& F_{1/J_1}^{-1} J_1^{-1}J_2 F_{2/J_2}
             \f}
             Thus
             \f{equation}
-            rhs_{impl} = \log_{\mathbf{R}^3\times SO(3)}\left( F_{2/J_2}^{-1}
-            \exp_{SE(3)} (rhs_{expl})  F_{2/J_2}\right)
+            rhs_{impl} = F_{2/J_2}^{-1} \exp_{SE(3)}(rhs_{expl}) F_{2/J_2}
             \f}
         */
         void explicitToImplicitRhs (vectorIn_t explicitRhs,
-                                    vectorOut_t implicitRhs) const;
+                                    LiegroupElementRef implicitRhs) const;
         // Create LiegroupSpace instances to avoid useless allocation.
         static LiegroupSpacePtr_t SE3;
         static LiegroupSpacePtr_t R3xSO3;

--- a/include/hpp/constraints/explicit/relative-pose.hh
+++ b/include/hpp/constraints/explicit/relative-pose.hh
@@ -39,8 +39,6 @@ namespace hpp {
         ///               constrained,
         /// \param frame1 position of a fixed frame in joint 1,
         /// \param frame2 position of a fixed frame in joint 2,
-        /// \param mask vector of 6 boolean defining which coordinates of the
-        ///        error vector to take into account.
         /// \param comp vector of comparison types
         /// \note if joint1 is 0x0, joint 1 frame is considered to be the global
         ///       frame.
@@ -91,8 +89,6 @@ namespace hpp {
         ///               constrained,
         /// \param frame1 position of a fixed frame in joint 1,
         /// \param frame2 position of a fixed frame in joint 2,
-        /// \param mask vector of 6 boolean defining which coordinates of the
-        ///        error vector to take into account.
         /// \param comp vector of comparison types
         /// \note if joint1 is 0x0, joint 1 frame is considered to be the global
         ///       frame.
@@ -100,7 +96,6 @@ namespace hpp {
                       const JointConstPtr_t& joint1,
                       const JointConstPtr_t& joint2,
                       const Transform3f& frame1, const Transform3f& frame2,
-                      std::vector <bool> mask = std::vector<bool>(6,true),
                       ComparisonTypes_t comp = ComparisonTypes_t());
 
         /// Copy constructor

--- a/include/hpp/constraints/explicit/relative-pose.hh
+++ b/include/hpp/constraints/explicit/relative-pose.hh
@@ -40,13 +40,16 @@ namespace hpp {
         /// \param frame1 position of a fixed frame in joint 1,
         /// \param frame2 position of a fixed frame in joint 2,
         /// \param comp vector of comparison types
+	/// \param mask mask defining which components of the error are
+	///        taken into account to determine whether the constraint
+	///        is satisfied.
         /// \note if joint1 is 0x0, joint 1 frame is considered to be the global
         ///       frame.
         static RelativePosePtr_t create
           (const std::string& name, const DevicePtr_t& robot,
            const JointConstPtr_t& joint1, const JointConstPtr_t& joint2,
            const Transform3f& frame1, const Transform3f& frame2,
-           ComparisonTypes_t comp);
+           ComparisonTypes_t comp, std::vector<bool> mask=std::vector<bool>());
 
         static RelativePosePtr_t createCopy (const RelativePosePtr_t& other);
 
@@ -90,13 +93,17 @@ namespace hpp {
         /// \param frame1 position of a fixed frame in joint 1,
         /// \param frame2 position of a fixed frame in joint 2,
         /// \param comp vector of comparison types
+	/// \param mask mask defining which components of the error are
+	///        taken into account to determine whether the constraint
+	///        is satisfied.
         /// \note if joint1 is 0x0, joint 1 frame is considered to be the global
         ///       frame.
         RelativePose (const std::string& name, const DevicePtr_t& robot,
                       const JointConstPtr_t& joint1,
                       const JointConstPtr_t& joint2,
                       const Transform3f& frame1, const Transform3f& frame2,
-                      ComparisonTypes_t comp = ComparisonTypes_t());
+                      ComparisonTypes_t comp = ComparisonTypes_t(),
+		      std::vector<bool> mask = std::vector<bool>(6, true));
 
         /// Copy constructor
         RelativePose (const RelativePose& other);

--- a/include/hpp/constraints/fwd.hh
+++ b/include/hpp/constraints/fwd.hh
@@ -136,7 +136,7 @@ namespace hpp {
     const int RelativeBit       = 0x1;
     const int PositionBit       = 0x2;
     const int OrientationBit    = 0x4;
-    const int OutputSE3Bit      = 0x8;
+    const int OutputR3xSO3Bit      = 0x8;
     /// \endcond DEVEL
     typedef GenericTransformation<               PositionBit | OrientationBit > Transformation;
     typedef GenericTransformation<               PositionBit                  > Position;
@@ -144,10 +144,10 @@ namespace hpp {
     typedef GenericTransformation< RelativeBit | PositionBit | OrientationBit > RelativeTransformation;
     typedef GenericTransformation< RelativeBit | PositionBit                  > RelativePosition;
     typedef GenericTransformation< RelativeBit |               OrientationBit > RelativeOrientation;
-    typedef GenericTransformation<               PositionBit | OrientationBit | OutputSE3Bit > TransformationSE3;
-    typedef GenericTransformation< RelativeBit | PositionBit | OrientationBit | OutputSE3Bit > RelativeTransformationR3xSO3;
-    typedef GenericTransformation<                             OrientationBit | OutputSE3Bit > OrientationSO3;
-    typedef GenericTransformation< RelativeBit |               OrientationBit | OutputSE3Bit > RelativeOrientationSO3;
+    typedef GenericTransformation<               PositionBit | OrientationBit | OutputR3xSO3Bit > TransformationR3xSO3;
+    typedef GenericTransformation< RelativeBit | PositionBit | OrientationBit | OutputR3xSO3Bit > RelativeTransformationR3xSO3;
+    typedef GenericTransformation<                             OrientationBit | OutputR3xSO3Bit > OrientationSO3;
+    typedef GenericTransformation< RelativeBit |               OrientationBit | OutputR3xSO3Bit > RelativeOrientationSO3;
 
     typedef boost::shared_ptr<Position> PositionPtr_t;
     typedef boost::shared_ptr<Orientation> OrientationPtr_t;

--- a/include/hpp/constraints/fwd.hh
+++ b/include/hpp/constraints/fwd.hh
@@ -145,7 +145,7 @@ namespace hpp {
     typedef GenericTransformation< RelativeBit | PositionBit                  > RelativePosition;
     typedef GenericTransformation< RelativeBit |               OrientationBit > RelativeOrientation;
     typedef GenericTransformation<               PositionBit | OrientationBit | OutputSE3Bit > TransformationSE3;
-    typedef GenericTransformation< RelativeBit | PositionBit | OrientationBit | OutputSE3Bit > RelativeTransformationSE3;
+    typedef GenericTransformation< RelativeBit | PositionBit | OrientationBit | OutputSE3Bit > RelativeTransformationR3xSO3;
     typedef GenericTransformation<                             OrientationBit | OutputSE3Bit > OrientationSO3;
     typedef GenericTransformation< RelativeBit |               OrientationBit | OutputSE3Bit > RelativeOrientationSO3;
 

--- a/include/hpp/constraints/generic-transformation.hh
+++ b/include/hpp/constraints/generic-transformation.hh
@@ -119,23 +119,25 @@ namespace hpp {
         IsRelative         = _Options & RelativeBit,
         ComputeOrientation = _Options & OrientationBit,
         ComputePosition    = _Options & PositionBit,
-        OutputSE3          = _Options & OutputSE3Bit,
+        OutputR3xSO3          = _Options & OutputR3xSO3Bit,
         IsPosition         = ComputePosition  && !ComputeOrientation,
         IsOrientation      = !ComputePosition && ComputeOrientation,
         IsTransform        = ComputePosition  && ComputeOrientation;
       static constexpr int
-        ValueSize          = (ComputePosition?3:0) + (ComputeOrientation?(OutputSE3?4:3):0),
+        ValueSize          = (ComputePosition?3:0) +
+	(ComputeOrientation?(OutputR3xSO3?4:3):0),
         DerSize            = (ComputePosition?3:0) + (ComputeOrientation ?3:0);
 #else
       enum {
         IsRelative         = _Options & RelativeBit,
         ComputeOrientation = _Options & OrientationBit,
         ComputePosition    = _Options & PositionBit,
-        OutputSE3          = _Options & OutputSE3Bit,
+        OutputR3xSO3          = _Options & OutputR3xSO3Bit,
         IsPosition         = ComputePosition  && !ComputeOrientation,
         IsOrientation      = !ComputePosition && ComputeOrientation,
         IsTransform        = ComputePosition  && ComputeOrientation,
-        ValueSize          = (ComputePosition?3:0) + (ComputeOrientation?(OutputSE3?4:3):0),
+        ValueSize          = (ComputePosition?3:0) +
+	(ComputeOrientation?(OutputR3xSO3?4:3):0),
         DerSize            = (ComputePosition?3:0) + (ComputeOrientation ?3:0)
         };
 #endif

--- a/include/hpp/constraints/implicit-constraint-set.hh
+++ b/include/hpp/constraints/implicit-constraint-set.hh
@@ -72,6 +72,8 @@ namespace hpp {
 	  // Handle mask
 	  mask_.insert(mask_.end(), constraint->mask_.begin(),
 		       constraint->mask_.end());
+	  // Recompute active rows
+	  computeActiveRows();
         }
 
         /// Get indices of constraint coordinates that are equality

--- a/include/hpp/constraints/implicit-constraint-set.hh
+++ b/include/hpp/constraints/implicit-constraint-set.hh
@@ -62,24 +62,18 @@ namespace hpp {
           // Handle comparison types
           const ComparisonTypes_t& comp (constraint->comparisonType ());
           for (std::size_t i = 0; i < comp.size(); ++i) {
-            if ((comp[i] == Superior) && (comp[i] == Inferior))
-            {
-              inequalityIndices_.push_back (comparison_.size());
-            }
-            else if (comp[i] == Equality)
+            if (comp[i] == Equality)
             {
               equalityIndices_.addRow(comparison_.size(), 1);
             }
             comparison_.push_back (comp[i]);
           }
           equalityIndices_.updateRows<true, true, true>();
+	  // Handle mask
+	  mask_.insert(mask_.end(), constraint->mask_.begin(),
+		       constraint->mask_.end());
         }
 
-        /// Get indices of constraint coordinates that are inequality
-        const std::vector<std::size_t>& inequalityIndices () const
-        {
-          return inequalityIndices_;
-        }
         /// Get indices of constraint coordinates that are equality
         const Eigen::RowBlockIndices& equalityIndices () const
         {
@@ -113,18 +107,18 @@ namespace hpp {
         /// \param name the name of the constraints,
         ImplicitConstraintSet (const std::string& name)
           : Implicit (DifferentiableFunctionSet::create (name),
-                      ComparisonTypes_t ())
+                      ComparisonTypes_t (), std::vector<bool>())
         {
         }
 
         ImplicitConstraintSet ()
           : Implicit (DifferentiableFunctionSet::create ("Stack"),
-                      ComparisonTypes_t ())
+                      ComparisonTypes_t (), std::vector<bool>())
           {}
 
         ImplicitConstraintSet (const ImplicitConstraintSet& o)
           : Implicit (DifferentiableFunctionSet::create ("Stack"),
-                      ComparisonTypes_t ())
+                      ComparisonTypes_t (), std::vector<bool>())
           {
             const Implicits_t& constraints = o.constraints();
             for (Implicits_t::const_iterator constraint = constraints.begin();
@@ -134,8 +128,6 @@ namespace hpp {
         
       private:
         Implicits_t constraints_;
-        ComparisonTypes_t comparison_;
-        std::vector<std::size_t> inequalityIndices_;
         Eigen::RowBlockIndices equalityIndices_;
 
         HPP_SERIALIZABLE();

--- a/include/hpp/constraints/implicit.hh
+++ b/include/hpp/constraints/implicit.hh
@@ -32,7 +32,8 @@ namespace hpp {
     */
     /**
         This class represents a parameterizable numerical constraint that
-        compares the output of a function \f$h\f$ to a right hand side vector.
+        compares the output of a function \f$h\f$ to a right hand side Lie
+	group element.
 
         \par Definition
         \li The function \f$h\f$ takes input in a configuration space
@@ -44,7 +45,7 @@ namespace hpp {
         enum hpp::contraints::ComparisonType = {
         \f$\mathbf{Equality}\f$, \f$\mathbf{EqualToZero}\f$,
         \f$\mathbf{Inferior}\f$, \f$\mathbf{Superior}\f$ }.
-        \li The right hand side is a vector of dimension \f$n_q\f$.
+        \li The right hand side is Lie group element of dimension \f$n_q\f$.
 
         \par Error
         A configuration \f$\mathbf{q}\f$ is said to satisfy the constraint for

--- a/include/hpp/constraints/implicit.hh
+++ b/include/hpp/constraints/implicit.hh
@@ -118,12 +118,6 @@ namespace hpp {
         virtual ImplicitPtr_t copy () const;
         /// Create a shared pointer to a new instance.
         /// \sa constructors
-        /// \deprecated Use method with comparison types
-        static ImplicitPtr_t create(const DifferentiableFunctionPtr_t& function)
-          HPP_CONSTRAINTS_DEPRECATED;
-
-        /// Create a shared pointer to a new instance.
-        /// \sa constructors
         static ImplicitPtr_t create
           (const DifferentiableFunctionPtr_t& func, ComparisonTypes_t comp,
 	   std::vector<bool> mask = std::vector<bool>());
@@ -221,15 +215,6 @@ namespace hpp {
         ///          function output space \f$\mathbf{L}\f$.
         Implicit (const DifferentiableFunctionPtr_t& function,
 		  ComparisonTypes_t comp, std::vector<bool> mask);
-
-        /// Constructor
-        /// \param function the differentiable function,
-        /// \param comp vector of comparison \f$\mathbf{c}\f$,
-        /// \param rhs the right hand side of the equation.
-        /// \precond size of comp and size of rhs should be equal to size of
-        ///          tangent space to function output space \f$\mathbf{L}\f$.
-        Implicit (const DifferentiableFunctionPtr_t& function,
-            ComparisonTypes_t comp, vectorIn_t rhs);
 
 	/// Copy constructor
 	Implicit (const Implicit& other);

--- a/include/hpp/constraints/implicit.hh
+++ b/include/hpp/constraints/implicit.hh
@@ -21,6 +21,7 @@
 # include <hpp/constraints/fwd.hh>
 # include <hpp/constraints/config.hh>
 # include <hpp/constraints/comparison-types.hh>
+# include <hpp/constraints/matrix-view.hh>
 
 # include <hpp/util/serialization-fwd.hh>
 
@@ -73,7 +74,8 @@ namespace hpp {
 	A mask is a vector of Boolean values of size \f$n_v\f$. Values set to
 	false means that the corresponding component of the error defined above
 	is not taken into account to determine whether the constraint is
-	satisfied.
+	satisfied. The active rows of the constraint may be accessed via
+	method activeRows.
 
         \par Parameterizable right hand side
 
@@ -191,6 +193,16 @@ namespace hpp {
 	/// Set the comparison type
 	void comparisonType (const ComparisonTypes_t& comp);
 
+	const segments_t& activeRows() const
+	{
+	  return activeRows_;
+	}
+
+	/// Set inactive components of error to 0
+	/// \retval error error vector computed by substracting a right hand
+	///         side to the output to the value of the function.
+	void setInactiveRowsToZero(vectorOut_t error) const;
+
         /// Return a reference to function \f$h\f$.
         DifferentiableFunction& function () const
         {
@@ -232,12 +244,15 @@ namespace hpp {
 
         friend class ImplicitConstraintSet;
       private:
+	void computeActiveRows();
         ComparisonTypes_t comparison_;
         vector_t rhs_;
         size_type parameterSize_;
         DifferentiableFunctionPtr_t function_;
         DifferentiableFunctionPtr_t rhsFunction_;
 	std::vector<bool> mask_;
+	segments_t activeRows_;
+	Eigen::RowBlockIndices inactiveRows_;
 	ImplicitWkPtr_t weak_;
 
       protected:

--- a/include/hpp/constraints/implicit.hh
+++ b/include/hpp/constraints/implicit.hh
@@ -159,12 +159,6 @@ namespace hpp {
         /// This is the dimension (nq) of the output space of the function
         size_type rightHandSideSize () const;
 
-        /// Return the ComparisonType
-        const ComparisonTypes_t& comparisonType () const;
-
-	/// Set the comparison type
-	void comparisonType (const ComparisonTypes_t& comp);
-
         /// Return a modifiable reference to right hand side of equation.
         /// \deprecated In future versions, right hand side will not be a member
         ///             of the class anymore.
@@ -190,6 +184,12 @@ namespace hpp {
         vectorIn_t rightHandSideAt (const value_type& s);
 
         /// \}
+
+        /// Return the ComparisonType
+        const ComparisonTypes_t& comparisonType () const;
+
+	/// Set the comparison type
+	void comparisonType (const ComparisonTypes_t& comp);
 
         /// Return a reference to function \f$h\f$.
         DifferentiableFunction& function () const

--- a/include/hpp/constraints/implicit.hh
+++ b/include/hpp/constraints/implicit.hh
@@ -36,6 +36,7 @@ namespace hpp {
 	group element.
 
         \par Definition
+
         \li The function \f$h\f$ takes input in a configuration space
         \f$\mathcal{C}\f$ and output in a Lie group \f$\mathbf{L}\f$,
         \li the dimensions of \f$\mathbf{L}\f$ and of its tangent space are
@@ -48,6 +49,7 @@ namespace hpp {
         \li The right hand side is Lie group element of dimension \f$n_q\f$.
 
         \par Error
+
         A configuration \f$\mathbf{q}\f$ is said to satisfy the constraint for
         a given right hand side if and only if the error \f$e\f$ as computed
         below is
@@ -66,7 +68,15 @@ namespace hpp {
         \f$e_i = \Delta_i\f$,
         \li if \f$c_i\f$ is \f$\mathbf{EqualToZero}\f$, \f$e_i = \Delta_i\f$.
 
+	\par Mask
+
+	A mask is a vector of Boolean values of size \f$n_v\f$. Values set to
+	false means that the corresponding component of the error defined above
+	is not taken into account to determine whether the constraint is
+	satisfied.
+
         \par Parameterizable right hand side
+
         Lines with \textbf{Equality} comparator in the above definition of the
         error need a parameter, while lines with comparators \textbf{Inferior},
         \textbf{Superior}, or \textbf{EqualToZero} do not.
@@ -115,13 +125,8 @@ namespace hpp {
         /// Create a shared pointer to a new instance.
         /// \sa constructors
         static ImplicitPtr_t create
-          (const DifferentiableFunctionPtr_t& function, ComparisonTypes_t comp);
-
-        /// Create a shared pointer to a new instance.
-        /// \sa constructors
-        static ImplicitPtr_t create
-          (const DifferentiableFunctionPtr_t& function,
-           ComparisonTypes_t comp, vectorIn_t rhs);
+          (const DifferentiableFunctionPtr_t& func, ComparisonTypes_t comp,
+	   std::vector<bool> mask = std::vector<bool>());
 
 	/// Create a copy and return shared pointer
 	static ImplicitPtr_t createCopy (const ImplicitPtr_t& other);
@@ -208,10 +213,14 @@ namespace hpp {
         /// Constructor
         /// \param function the differentiable function
         /// \param comp vector of comparison \f$\mathbf{c}\f$.
-        /// \precond size of comp should be equal to size of tangent space to
+	/// \param mask mask defining which components of the error are
+	///        taken into account to determine whether the constraint
+	///        is satisfied.
+        /// \precond sizes of comp and of mask should be equal to size of
+	///          tangent space to
         ///          function output space \f$\mathbf{L}\f$.
         Implicit (const DifferentiableFunctionPtr_t& function,
-            ComparisonTypes_t comp);
+		  ComparisonTypes_t comp, std::vector<bool> mask);
 
         /// Constructor
         /// \param function the differentiable function,
@@ -243,6 +252,7 @@ namespace hpp {
         size_type parameterSize_;
         DifferentiableFunctionPtr_t function_;
         DifferentiableFunctionPtr_t rhsFunction_;
+	std::vector<bool> mask_;
 	ImplicitWkPtr_t weak_;
 
       protected:

--- a/include/hpp/constraints/matrix-view.hh
+++ b/include/hpp/constraints/matrix-view.hh
@@ -17,10 +17,12 @@
 #ifndef HPP_CONSTRAINTS_MATRIX_VIEW_HH
 #define HPP_CONSTRAINTS_MATRIX_VIEW_HH
 
+#include <boost/serialization/nvp.hpp>
 #include <Eigen/Core>
 #include <vector>
 #include <iostream>
 #include <hpp/util/indent.hh>
+#include <hpp/util/serialization-fwd.hh>
 #include <hpp/pinocchio/util.hh>
 #include <hpp/constraints/fwd.hh>
 
@@ -38,9 +40,9 @@ namespace Eigen {
     /// Index of vector or matrix
     typedef hpp::constraints::size_type size_type;
     /// Interval of indices [first, first + second - 1]
-    typedef std::pair<size_type, size_type> segment_t;
+    typedef hpp::constraints::segment_t segment_t;
     /// vector of segments
-    typedef std::vector<segment_t> segments_t;
+    typedef hpp::constraints::segments_t segments_t;
 
     /// Return the number of indices in the vector of segments.
     /// \param a vector of segments
@@ -143,6 +145,8 @@ namespace Eigen {
         template <typename In0_t, typename In1_t> empty_struct (In0_t, In1_t) {}
         static inline Index size() { return 1; }
         inline const Index& operator[](const Index& i) const { return i; }
+	template<class Archive>
+	inline void serialize(Archive &, const unsigned int){}
       };
       template <bool If> struct get_if { template <typename T1, typename T2> static EIGEN_STRONG_INLINE T1 run (T1 then, T2 Else) { (void)Else; return then; } };
       template <> struct get_if<false> { template <typename T1, typename T2> static EIGEN_STRONG_INLINE T2 run (T1 then, T2 Else) { (void)then; return Else; } };
@@ -678,6 +682,16 @@ namespace Eigen {
         if (Shrink)   BlockIndex::shrink(b);
         if (Cardinal) idx = BlockIndex::cardinal(b);
       }
+    template<class Archive>
+    void serialize(Archive & ar, const unsigned int version)
+    {
+      (void) version;
+      ar & BOOST_SERIALIZATION_NVP(m_nbRows);
+      ar & BOOST_SERIALIZATION_NVP(m_nbCols);
+      ar & BOOST_SERIALIZATION_NVP(m_rows);
+      ar & BOOST_SERIALIZATION_NVP(m_cols);
+    }
+    friend class boost::serialization::access;
   }; // class MatrixBlocks
 
   /// \cond

--- a/include/hpp/constraints/matrix-view.hh
+++ b/include/hpp/constraints/matrix-view.hh
@@ -682,16 +682,6 @@ namespace Eigen {
         if (Shrink)   BlockIndex::shrink(b);
         if (Cardinal) idx = BlockIndex::cardinal(b);
       }
-    template<class Archive>
-    void serialize(Archive & ar, const unsigned int version)
-    {
-      (void) version;
-      ar & BOOST_SERIALIZATION_NVP(m_nbRows);
-      ar & BOOST_SERIALIZATION_NVP(m_nbCols);
-      ar & BOOST_SERIALIZATION_NVP(m_rows);
-      ar & BOOST_SERIALIZATION_NVP(m_cols);
-    }
-    friend class boost::serialization::access;
   }; // class MatrixBlocks
 
   /// \cond

--- a/include/hpp/constraints/matrix-view.hh
+++ b/include/hpp/constraints/matrix-view.hh
@@ -17,12 +17,10 @@
 #ifndef HPP_CONSTRAINTS_MATRIX_VIEW_HH
 #define HPP_CONSTRAINTS_MATRIX_VIEW_HH
 
-#include <boost/serialization/nvp.hpp>
 #include <Eigen/Core>
 #include <vector>
 #include <iostream>
 #include <hpp/util/indent.hh>
-#include <hpp/util/serialization-fwd.hh>
 #include <hpp/pinocchio/util.hh>
 #include <hpp/constraints/fwd.hh>
 
@@ -145,8 +143,6 @@ namespace Eigen {
         template <typename In0_t, typename In1_t> empty_struct (In0_t, In1_t) {}
         static inline Index size() { return 1; }
         inline const Index& operator[](const Index& i) const { return i; }
-	template<class Archive>
-	inline void serialize(Archive &, const unsigned int){}
       };
       template <bool If> struct get_if { template <typename T1, typename T2> static EIGEN_STRONG_INLINE T1 run (T1 then, T2 Else) { (void)Else; return then; } };
       template <> struct get_if<false> { template <typename T1, typename T2> static EIGEN_STRONG_INLINE T2 run (T1 then, T2 Else) { (void)then; return Else; } };

--- a/include/hpp/constraints/solver/by-substitution.hh
+++ b/include/hpp/constraints/solver/by-substitution.hh
@@ -311,10 +311,6 @@ namespace hpp {
       }; // class BySubstitution
       /// \}
 
-      inline std::ostream& operator<< (std::ostream& os, const BySubstitution& hs)
-      {
-        return hs.print(os);
-      }
     } // namespace solver
   } // namespace constraints
 } // namespace hpp

--- a/include/hpp/constraints/solver/hierarchical-iterative.hh
+++ b/include/hpp/constraints/solver/hierarchical-iterative.hh
@@ -655,6 +655,11 @@ namespace hpp {
         HPP_SERIALIZABLE_SPLIT();
       }; // class HierarchicalIterative
       /// \}
+      inline std::ostream& operator<< (std::ostream& os,
+				       const HierarchicalIterative& hs)
+      {
+        return hs.print(os);
+      }
     } // namespace solver
   } // namespace constraints
 } // namespace hpp

--- a/include/hpp/constraints/solver/impl/by-substitution.hh
+++ b/include/hpp/constraints/solver/impl/by-substitution.hh
@@ -33,6 +33,7 @@ namespace hpp {
       assert (!arg.hasNaN());
 
       explicit_.solve(arg);
+      assert (!arg.hasNaN());
 
       size_type errorDecreased = 3, iter = 0;
       value_type previousSquaredNorm;
@@ -91,6 +92,7 @@ namespace hpp {
         // 3. Apply line search algorithm for the computed step
         lineSearch (*this, arg, dq_);
         explicit_.solve(arg);
+	assert (!arg.hasNaN());
 
         // 4. Evaluate the error at the new point.
 	computeValue<true> (arg);

--- a/src/convex-shape-contact.cc
+++ b/src/convex-shape-contact.cc
@@ -354,35 +354,39 @@ namespace hpp {
     }
 
     void ConvexShapeContactComplement::computeRelativePoseRightHandSide
-    (vectorIn_t rhs, std::size_t& ifloor, std::size_t& iobject,
-     vectorOut_t relativePoseRhs) const
+    (LiegroupElementConstRef rhs, std::size_t& ifloor, std::size_t& iobject,
+     LiegroupElementRef relativePoseRhs) const
     {
+      assert(*(rhs.space()) == *LiegroupSpace::Rn(8));
       value_type M(sibling_->radius());
-      relativePoseRhs.fill(sqrt(-1));
+      vector8_t logRhs(log(rhs));
+      vector6_t logRelativePoseRhs; logRelativePoseRhs.fill(sqrt(-1));
       // x
-      relativePoseRhs[0] = rhs[0];
+      logRelativePoseRhs[0] = logRhs[0];
       // ry, rz
-      relativePoseRhs.segment<2>(4) = rhs.segment<2>(3);
+      logRelativePoseRhs.segment<2>(4) = logRhs.segment<2>(3);
       // rx
-      relativePoseRhs[3] = rhs[7];
-      value_type Y(rhs[5]);
-      value_type Z(rhs[6]);
+      logRelativePoseRhs[3] = logRhs[7];
+      value_type Y(logRhs[5]);
+      value_type Z(logRhs[6]);
       assert(floor(Y/(2*M) + .5) >= 0);
       ifloor = (std::size_t)(floor(Y/(2*M) + .5));
       assert(floor(Z/(2*M) + .5) >= 0);
       iobject = (std::size_t)(floor(Z/(2*M) + .5));
-      if ((rhs[1] == 0) && (rhs[2] == 0))
+      if ((logRhs[1] == 0) && (logRhs[2] == 0))
       {
         // inside
-        relativePoseRhs[1] = Y - (value_type)(2*ifloor)*M;
-        relativePoseRhs[2] = Z - (value_type)(2*iobject)*M;
+        logRelativePoseRhs[1] = Y - (value_type)(2*ifloor)*M;
+        logRelativePoseRhs[2] = Z - (value_type)(2*iobject)*M;
       }
       else
       {
         // outside
-        relativePoseRhs.segment<2>(1) = rhs.segment<2>(1);
+        logRelativePoseRhs.segment<2>(1) = logRhs.segment<2>(1);
       }
-      assert(!relativePoseRhs.hasNaN());
+      assert(!logRelativePoseRhs.hasNaN());
+      relativePoseRhs = LiegroupSpace::R3xSO3()->exp(logRelativePoseRhs);
+      assert(*(relativePoseRhs.space()) == *LiegroupSpace::R3xSO3());
     }
         
 

--- a/src/explicit-constraint-set.cc
+++ b/src/explicit-constraint-set.cc
@@ -351,7 +351,8 @@ namespace hpp {
       d.constraint->function ().value (d.h_value, arg);
       vector_t logRhs(log(d.h_value));
       // Equality indices apply on the log of the right hand side
-      // This is necessary for constraints built with RelativeTransformationSE3.
+      // This is necessary for constraints built with
+      // RelativeTransformationR3xSO3.
       vector_t logRhsImplicit(vector_t::Zero(d.rhs_implicit.space()->nv()));
       d.equalityIndices.lview(logRhsImplicit) = d.equalityIndices.rview(logRhs);
       d.rhs_implicit = d.rhs_implicit.space()->exp(logRhsImplicit);

--- a/src/explicit.cc
+++ b/src/explicit.cc
@@ -78,11 +78,15 @@ namespace hpp {
      const segments_t& outputConf,
      const segments_t& inputVelocity,
      const segments_t& outputVelocity,
-     const ComparisonTypes_t& comp)
+     const ComparisonTypes_t& comp, std::vector<bool> mask)
     {
+      if (mask.empty()){
+	mask = std::vector<bool>(Eigen::BlockIndex::cardinal (outputVelocity),
+				 true);
+      }
       Explicit* ptr = new Explicit
 	(configSpace, function, inputConf, outputConf, inputVelocity,
-         outputVelocity, defaultCompTypes(outputVelocity,comp));
+         outputVelocity, defaultCompTypes(outputVelocity,comp), mask);
       ExplicitPtr_t shPtr (ptr);
       ExplicitWkPtr_t wkPtr (shPtr);
       ptr->init (wkPtr);
@@ -133,11 +137,11 @@ namespace hpp {
      const segments_t& outputConf,
      const segments_t& inputVelocity,
      const segments_t& outputVelocity,
-     const ComparisonTypes_t& comp) :
+     const ComparisonTypes_t& comp, std::vector<bool> mask) :
       Implicit (explicit_::ImplicitFunction::create
                 (configSpace, explicitFunction, inputConf,
                  outputConf, inputVelocity, outputVelocity),
-                comp),
+                comp, mask),
       inputToOutput_ (explicitFunction),
       inputConf_ (inputConf),
       outputConf_ (outputConf),
@@ -153,8 +157,8 @@ namespace hpp {
      const segments_t& outputConf,
      const segments_t& inputVelocity,
      const segments_t& outputVelocity,
-     const ComparisonTypes_t& comp) :
-      Implicit (implicitFunction, comp),
+     const ComparisonTypes_t& comp, std::vector<bool> mask) :
+      Implicit (implicitFunction, comp, mask),
       inputToOutput_ (explicitFunction),
       inputConf_ (inputConf),
       outputConf_ (outputConf),

--- a/src/explicit.cc
+++ b/src/explicit.cc
@@ -101,21 +101,23 @@ namespace hpp {
     }
 
     void Explicit::outputValue(LiegroupElementRef result, vectorIn_t qin,
-                               vectorIn_t rhs) const
+                               LiegroupElementConstRef rhs) const
     {
       explicitFunction ()->value(result, qin);
-      result += rhs;
+      assert(rhs.space()->isVectorSpace());
+      result += rhs.vector();
     }
 
     void Explicit::jacobianOutputValue(vectorIn_t qin, LiegroupElementConstRef
-                                       f_value, vectorIn_t rhs,
+                                       f_value, LiegroupElementConstRef rhs,
                                        matrixOut_t jacobian) const
     {
+      assert(rhs.space()->isVectorSpace());
       explicitFunction ()->jacobian(jacobian, qin);
-      if (!rhs.isZero())
+      if (!rhs.vector().isZero())
       {
         explicitFunction ()->outputSpace ()->dIntegrate_dq
-          <pinocchio::DerivativeTimesInput> (f_value, rhs, jacobian);
+          <pinocchio::DerivativeTimesInput> (f_value, rhs.vector(), jacobian);
       }
     }
 

--- a/src/explicit/convex-shape-contact.cc
+++ b/src/explicit/convex-shape-contact.cc
@@ -80,14 +80,14 @@ namespace hpp {
         return createCopy (weak_.lock ());
       }
 
-       void ConvexShapeContact::outputValue
-       (LiegroupElementRef result, vectorIn_t qin, vectorIn_t rhs) const
+       void ConvexShapeContact::outputValue(LiegroupElementRef result,
+	                   vectorIn_t qin, LiegroupElementConstRef rhs) const
        {
         assert(HPP_DYNAMIC_PTR_CAST(ConvexShapeContactHold, functionPtr()));
         ConvexShapeContactHoldPtr_t f(HPP_STATIC_PTR_CAST
                                       (ConvexShapeContactHold, functionPtr()));
         std::size_t ifloor, iobject;
-        vector6_t relativePoseRhs;
+        LiegroupElement relativePoseRhs(LiegroupSpace::R3xSO3());
         f->complement()->computeRelativePoseRightHandSide
           (rhs, ifloor, iobject, relativePoseRhs);
         // Extract input configuration of relative pose from qin
@@ -102,14 +102,14 @@ namespace hpp {
        }
 
       void ConvexShapeContact::jacobianOutputValue
-      (vectorIn_t qin, LiegroupElementConstRef, vectorIn_t rhs,
+      (vectorIn_t qin, LiegroupElementConstRef, LiegroupElementConstRef rhs,
        matrixOut_t jacobian) const
       {
         assert(HPP_DYNAMIC_PTR_CAST(ConvexShapeContactHold, functionPtr()));
         ConvexShapeContactHoldPtr_t f(HPP_STATIC_PTR_CAST
                                       (ConvexShapeContactHold, functionPtr()));
         std::size_t ifloor, iobject;
-        vector6_t relativePoseRhs;
+        LiegroupElement relativePoseRhs(LiegroupSpace::R3xSO3());
         f->complement()->computeRelativePoseRightHandSide
           (rhs, ifloor, iobject, relativePoseRhs);
         // Extract input configuration of relative pose from qin
@@ -120,7 +120,7 @@ namespace hpp {
         Eigen::RowBlockIndices relPosInputIndices(relativePose->inputConf());
         vector_t qinRelPose = relPosInputIndices.rview(q);
         assert(!qinRelPose.hasNaN());
-        LiegroupElement outputRelPose(LiegroupSpace::SE3());
+        LiegroupElement outputRelPose(LiegroupSpace::R3xSO3());
         relativePose->outputValue(outputRelPose, qinRelPose, relativePoseRhs);
         relativePose->jacobianOutputValue(qinRelPose, outputRelPose,
                                           relativePoseRhs, jacobian);

--- a/src/explicit/convex-shape-contact.cc
+++ b/src/explicit/convex-shape-contact.cc
@@ -144,7 +144,7 @@ namespace hpp {
                  contact::inputVelocityVariables
                  (robot, floorSurfaces, objectSurfaces),
                  relativePose::jointVelInterval(objectSurfaces.front().first),
-                 (5 * EqualToZero << 3 * Equality))
+                 (5 * EqualToZero << 3 * Equality), std::vector<bool>(8,true))
       {
         assert(HPP_DYNAMIC_PTR_CAST(ConvexShapeContactHold, functionPtr()));
         ConvexShapeContactHoldPtr_t f
@@ -170,7 +170,7 @@ namespace hpp {
             pose_.push_back(RelativePose::create
                             ("",robot, fs[j].joint_, os[i].joint_,
                              posInJoint, os[i].positionInJoint(),
-                             6 * Equality));
+                             6 * Equality, std::vector<bool>(6, true)));
           }
         }
       }

--- a/src/explicit/relative-pose.cc
+++ b/src/explicit/relative-pose.cc
@@ -131,7 +131,7 @@ namespace hpp {
        const JointConstPtr_t& joint1, const JointConstPtr_t& joint2,
        const Transform3f& frame1, const Transform3f& frame2,
        ComparisonTypes_t comp, std::vector<bool> mask) :
-        Explicit (RelativeTransformationSE3::create
+        Explicit (RelativeTransformationR3xSO3::create
                   (name, robot, joint1, joint2, frame1, frame2,
 		   std::vector<bool>(6,true)),
                   RelativeTransformation::create

--- a/src/explicit/relative-pose.cc
+++ b/src/explicit/relative-pose.cc
@@ -36,8 +36,7 @@ namespace hpp {
          ComparisonTypes_t comp)
       {
         RelativePose* ptr (new RelativePose
-                           (name, robot, joint1, joint2, frame1, frame2,
-                            std::vector<bool>(6,true), comp));
+                           (name, robot, joint1, joint2, frame1, frame2, comp));
         RelativePosePtr_t shPtr (ptr);
         RelativePoseWkPtr_t wkPtr (shPtr);
         ptr->init (wkPtr);
@@ -128,10 +127,11 @@ namespace hpp {
       (const std::string& name, const DevicePtr_t& robot,
        const JointConstPtr_t& joint1, const JointConstPtr_t& joint2,
        const Transform3f& frame1, const Transform3f& frame2,
-       std::vector <bool> mask, ComparisonTypes_t comp) :
+       ComparisonTypes_t comp) :
         Explicit (GenericTransformation
                   <RelativeBit | PositionBit | OrientationBit>::create
-                  (name, robot, joint1, joint2, frame1, frame2, mask),
+                  (name, robot, joint1, joint2, frame1, frame2,
+		   std::vector<bool>(6,true)),
                   RelativeTransformation::create
                   (name, robot, joint1, joint2, frame1, frame2),
                   relativePose::inputConfVariables (robot, joint1, joint2),

--- a/src/explicit/relative-pose.cc
+++ b/src/explicit/relative-pose.cc
@@ -33,10 +33,15 @@ namespace hpp {
         (const std::string& name, const DevicePtr_t& robot,
          const JointConstPtr_t& joint1, const JointConstPtr_t& joint2,
          const Transform3f& frame1, const Transform3f& frame2,
-         ComparisonTypes_t comp)
+         ComparisonTypes_t comp, std::vector<bool> mask)
       {
+	if (mask.empty())
+	{
+	  mask = std::vector<bool>(6,true);
+	}
         RelativePose* ptr (new RelativePose
-                           (name, robot, joint1, joint2, frame1, frame2, comp));
+                           (name, robot, joint1, joint2, frame1, frame2, comp,
+			    mask));
         RelativePosePtr_t shPtr (ptr);
         RelativePoseWkPtr_t wkPtr (shPtr);
         ptr->init (wkPtr);
@@ -125,7 +130,7 @@ namespace hpp {
       (const std::string& name, const DevicePtr_t& robot,
        const JointConstPtr_t& joint1, const JointConstPtr_t& joint2,
        const Transform3f& frame1, const Transform3f& frame2,
-       ComparisonTypes_t comp) :
+       ComparisonTypes_t comp, std::vector<bool> mask) :
         Explicit (RelativeTransformationSE3::create
                   (name, robot, joint1, joint2, frame1, frame2,
 		   std::vector<bool>(6,true)),
@@ -134,7 +139,7 @@ namespace hpp {
                   relativePose::inputConfVariables (robot, joint1, joint2),
                   relativePose::jointConfInterval (joint2),
                   relativePose::inputVelocityVariables (robot, joint1, joint2),
-                  relativePose::jointVelInterval (joint2), comp),
+                  relativePose::jointVelInterval (joint2), comp, mask),
         joint1_ (joint1), joint2_ (joint2), frame1_ (frame1), frame2_ (frame2)
       {
           assert ((*joint2->configurationSpace () ==

--- a/src/generic-transformation.cc
+++ b/src/generic-transformation.cc
@@ -280,7 +280,7 @@ namespace hpp {
     HPP_SERIALIZATION_IMPLEMENT(hpp::constraints::RelativeOrientation);
     HPP_SERIALIZATION_IMPLEMENT(hpp::constraints::RelativeTransformation);
     HPP_SERIALIZATION_IMPLEMENT(hpp::constraints::TransformationSE3);
-    HPP_SERIALIZATION_IMPLEMENT(hpp::constraints::RelativeTransformationSE3);
+    HPP_SERIALIZATION_IMPLEMENT(hpp::constraints::RelativeTransformationR3xSO3);
     HPP_SERIALIZATION_IMPLEMENT(hpp::constraints::OrientationSO3);
     HPP_SERIALIZATION_IMPLEMENT(hpp::constraints::RelativeOrientationSO3);
   } // namespace constraints
@@ -329,6 +329,6 @@ BOOST_CLASS_EXPORT(hpp::constraints::RelativePosition)
 BOOST_CLASS_EXPORT(hpp::constraints::RelativeOrientation)
 BOOST_CLASS_EXPORT(hpp::constraints::RelativeTransformation)
 BOOST_CLASS_EXPORT(hpp::constraints::TransformationSE3)
-BOOST_CLASS_EXPORT(hpp::constraints::RelativeTransformationSE3)
+BOOST_CLASS_EXPORT(hpp::constraints::RelativeTransformationR3xSO3)
 BOOST_CLASS_EXPORT(hpp::constraints::OrientationSO3)
 BOOST_CLASS_EXPORT(hpp::constraints::RelativeOrientationSO3)

--- a/src/generic-transformation.cc
+++ b/src/generic-transformation.cc
@@ -42,7 +42,7 @@ namespace hpp {
       assert (mask[(pos ? 3 : 0) + 0]
           &&  mask[(pos ? 3 : 0) + 1]
           &&  mask[(pos ? 3 : 0) + 2]
-          && "Full orientation is necessary to output SE3 / SO3 error");
+          && "Full orientation is necessary to output R3xSO3 / SO3 error");
       const size_type nTranslation = size(mask) - 3;
       LiegroupSpacePtr_t SO3 = LiegroupSpace::SO3();
       switch (nTranslation) {
@@ -64,7 +64,7 @@ namespace hpp {
         assert (mask[(pos ? 3 : 0) + 0]
             &&  mask[(pos ? 3 : 0) + 1]
             &&  mask[(pos ? 3 : 0) + 2]
-            && "Full orientation is necessary to output SE3 / SO3 error");
+            && "Full orientation is necessary to output R3xSO3 / SO3 error");
         _mask[_mask.size()-1] = true;
       }
       return Eigen::RowBlockIndices (Eigen::BlockIndex::fromLogicalExpression (_mask));
@@ -166,11 +166,11 @@ namespace hpp {
       (const std::string& name, const DevicePtr_t& robot,
        std::vector <bool> mask) :
         DifferentiableFunction (robot->configSize (), robot->numberDof (),
-            liegroupSpace <(bool)ComputePosition, (bool)ComputeOrientation, (bool)OutputSE3> (mask),
+            liegroupSpace <(bool)ComputePosition, (bool)ComputeOrientation, (bool)OutputR3xSO3> (mask),
             name),
         robot_ (robot),
         m_(robot->numberDof()-robot->extraConfigSpace().dimension()),
-        Vindices_ (indices<(bool)ComputePosition, (bool)ComputeOrientation, (bool)OutputSE3> (mask)),
+        Vindices_ (indices<(bool)ComputePosition, (bool)ComputeOrientation, (bool)OutputR3xSO3> (mask)),
         mask_ (mask)
     {
       assert(mask.size()==DerSize);
@@ -200,11 +200,11 @@ namespace hpp {
     void GenericTransformation<_Options>::impl_compute
     (LiegroupElementRef result, ConfigurationIn_t argument) const
     {
-      GTDataV<IsRelative, (bool)ComputePosition, (bool)ComputeOrientation, (bool)OutputSE3> data (m_, robot_);
+      GTDataV<IsRelative, (bool)ComputePosition, (bool)ComputeOrientation, (bool)OutputR3xSO3> data (m_, robot_);
 
       data.device.currentConfiguration (argument);
       data.device.computeForwardKinematics ();
-      compute<IsRelative, (bool)ComputePosition, (bool)ComputeOrientation, (bool)OutputSE3>::error (data);
+      compute<IsRelative, (bool)ComputePosition, (bool)ComputeOrientation, (bool)OutputR3xSO3>::error (data);
 
       result.vector() = Vindices_.rview (data.value);
     }
@@ -218,12 +218,12 @@ namespace hpp {
       // support multithreadind. To avoid it, DeviceData should provide some
       // a temporary buffer to pass to an Eigen::Map
       {
-      GTDataJ<IsRelative, (bool)ComputePosition, (bool)ComputeOrientation, (bool)OutputSE3> data (m_, robot_);
+      GTDataJ<IsRelative, (bool)ComputePosition, (bool)ComputeOrientation, (bool)OutputR3xSO3> data (m_, robot_);
 
       data.device.currentConfiguration (arg);
       data.device.computeForwardKinematics ();
-      compute<IsRelative, (bool)ComputePosition, (bool)ComputeOrientation, (bool)OutputSE3>::error (data);
-      compute<IsRelative, (bool)ComputePosition, (bool)ComputeOrientation, (bool)OutputSE3>::jacobian (data, jacobian, mask_);
+      compute<IsRelative, (bool)ComputePosition, (bool)ComputeOrientation, (bool)OutputR3xSO3>::error (data);
+      compute<IsRelative, (bool)ComputePosition, (bool)ComputeOrientation, (bool)OutputR3xSO3>::jacobian (data, jacobian, mask_);
       }
 
 #ifdef CHECK_JACOBIANS
@@ -266,12 +266,12 @@ namespace hpp {
     template class GenericTransformation< RelativeBit | PositionBit                  >;
     template class GenericTransformation< RelativeBit |               OrientationBit >;
 
-    template class GenericTransformation< OutputSE3Bit |               PositionBit | OrientationBit >;
-    // template class GenericTransformation< OutputSE3Bit |               PositionBit                  >;
-    template class GenericTransformation< OutputSE3Bit |                             OrientationBit >;
-    template class GenericTransformation< OutputSE3Bit | RelativeBit | PositionBit | OrientationBit >;
-    // template class GenericTransformation< OutputSE3Bit | RelativeBit | PositionBit                  >;
-    template class GenericTransformation< OutputSE3Bit | RelativeBit |               OrientationBit >;
+    template class GenericTransformation< OutputR3xSO3Bit |               PositionBit | OrientationBit >;
+    // template class GenericTransformation< OutputR3xSO3Bit |               PositionBit                  >;
+    template class GenericTransformation< OutputR3xSO3Bit |                             OrientationBit >;
+    template class GenericTransformation< OutputR3xSO3Bit | RelativeBit | PositionBit | OrientationBit >;
+    // template class GenericTransformation< OutputR3xSO3Bit | RelativeBit | PositionBit                  >;
+    template class GenericTransformation< OutputR3xSO3Bit | RelativeBit |               OrientationBit >;
 
     HPP_SERIALIZATION_IMPLEMENT(hpp::constraints::Position);
     HPP_SERIALIZATION_IMPLEMENT(hpp::constraints::Orientation);
@@ -279,7 +279,7 @@ namespace hpp {
     HPP_SERIALIZATION_IMPLEMENT(hpp::constraints::RelativePosition);
     HPP_SERIALIZATION_IMPLEMENT(hpp::constraints::RelativeOrientation);
     HPP_SERIALIZATION_IMPLEMENT(hpp::constraints::RelativeTransformation);
-    HPP_SERIALIZATION_IMPLEMENT(hpp::constraints::TransformationSE3);
+    HPP_SERIALIZATION_IMPLEMENT(hpp::constraints::TransformationR3xSO3);
     HPP_SERIALIZATION_IMPLEMENT(hpp::constraints::RelativeTransformationR3xSO3);
     HPP_SERIALIZATION_IMPLEMENT(hpp::constraints::OrientationSO3);
     HPP_SERIALIZATION_IMPLEMENT(hpp::constraints::RelativeOrientationSO3);
@@ -328,7 +328,7 @@ BOOST_CLASS_EXPORT(hpp::constraints::Transformation)
 BOOST_CLASS_EXPORT(hpp::constraints::RelativePosition)
 BOOST_CLASS_EXPORT(hpp::constraints::RelativeOrientation)
 BOOST_CLASS_EXPORT(hpp::constraints::RelativeTransformation)
-BOOST_CLASS_EXPORT(hpp::constraints::TransformationSE3)
+BOOST_CLASS_EXPORT(hpp::constraints::TransformationR3xSO3)
 BOOST_CLASS_EXPORT(hpp::constraints::RelativeTransformationR3xSO3)
 BOOST_CLASS_EXPORT(hpp::constraints::OrientationSO3)
 BOOST_CLASS_EXPORT(hpp::constraints::RelativeOrientationSO3)

--- a/src/generic-transformation.cc
+++ b/src/generic-transformation.cc
@@ -50,7 +50,7 @@ namespace hpp {
         case 1: return LiegroupSpace::R1() * SO3;
         case 2: return LiegroupSpace::R2() * SO3;
         case 3: return LiegroupSpace::R3xSO3();
-        default: throw std::logic_error ("This should not happend. Invalid mask.");
+        default: throw std::logic_error ("This should not happen. Invalid mask.");
       }
     }
 

--- a/src/implicit.cc
+++ b/src/implicit.cc
@@ -228,9 +228,10 @@ namespace hpp {
         parameterSize_ = computeParameterSize (comparison_);
       ar & BOOST_SERIALIZATION_NVP(function_);
       ar & BOOST_SERIALIZATION_NVP(rhsFunction_);
-      ar & BOOST_SERIALIZATION_NVP(activeRows_);
-      ar & BOOST_SERIALIZATION_NVP(inactiveRows_);
+      ar & BOOST_SERIALIZATION_NVP(mask_);
       ar & BOOST_SERIALIZATION_NVP(weak_);
+      if (!Archive::is_saving::value)
+        computeActiveRows();
     }
 
     HPP_SERIALIZATION_IMPLEMENT(Implicit);

--- a/src/implicit.cc
+++ b/src/implicit.cc
@@ -166,19 +166,6 @@ namespace hpp {
     }
 
     ImplicitPtr_t Implicit::create (
-        const DifferentiableFunctionPtr_t& function)
-    {
-      ComparisonTypes_t comp
-        (function->outputDerivativeSize(), constraints::EqualToZero);
-
-      Implicit* ptr = new Implicit (function, comp);
-      ImplicitPtr_t shPtr (ptr);
-      ImplicitWkPtr_t wkPtr (shPtr);
-      ptr->init (wkPtr);
-      return shPtr;
-    }
-
-    ImplicitPtr_t Implicit::create (
 	const DifferentiableFunctionPtr_t& function, ComparisonTypes_t comp,
 	std::vector<bool> mask)
     {
@@ -186,17 +173,6 @@ namespace hpp {
 	mask = std::vector<bool>(function->outputSpace()->nv());
       }	
       Implicit* ptr = new Implicit (function, comp, mask);
-      ImplicitPtr_t shPtr (ptr);
-      ImplicitWkPtr_t wkPtr (shPtr);
-      ptr->init (wkPtr);
-      return shPtr;
-    }
-
-    ImplicitPtr_t Implicit::create (
-        const DifferentiableFunctionPtr_t& function,
-        ComparisonTypes_t comp, vectorIn_t rhs)
-    {
-      Implicit* ptr = new Implicit (function, comp, rhs);
       ImplicitPtr_t shPtr (ptr);
       ImplicitWkPtr_t wkPtr (shPtr);
       ptr->init (wkPtr);

--- a/src/implicit.cc
+++ b/src/implicit.cc
@@ -118,16 +118,18 @@ namespace hpp {
     }
 
     Implicit::Implicit (const DifferentiableFunctionPtr_t& function,
-                        ComparisonTypes_t comp) :
+                        ComparisonTypes_t comp, std::vector<bool> mask) :
       comparison_ (comp), rhs_ (vector_t::Zero (function->outputSize ())),
       parameterSize_ (computeParameterSize (comparison_)),
-      function_ (function)
+      function_ (function), mask_(mask)
     {
       // This constructor used to set comparison types to Equality if an
       // empty vector was given as input. Now you should provide the
       // comparison type at construction.
       assert
         (function_->outputDerivativeSize () == (size_type)comparison_.size ());
+      assert
+        (function_->outputDerivativeSize () == (size_type)mask_.size ());
     }
 
     Implicit::Implicit (const DifferentiableFunctionPtr_t& function,
@@ -177,9 +179,13 @@ namespace hpp {
     }
 
     ImplicitPtr_t Implicit::create (
-        const DifferentiableFunctionPtr_t& function, ComparisonTypes_t comp)
+	const DifferentiableFunctionPtr_t& function, ComparisonTypes_t comp,
+	std::vector<bool> mask)
     {
-      Implicit* ptr = new Implicit (function, comp);
+      if (mask.empty()){
+	mask = std::vector<bool>(function->outputSpace()->nv());
+      }	
+      Implicit* ptr = new Implicit (function, comp, mask);
       ImplicitPtr_t shPtr (ptr);
       ImplicitWkPtr_t wkPtr (shPtr);
       ptr->init (wkPtr);

--- a/src/locked-joint.cc
+++ b/src/locked-joint.cc
@@ -133,7 +133,8 @@ namespace hpp {
                 segments_t(), // input vel
                 list_of(segment_t (joint->rankInVelocity     (),
                                    joint->numberDof ())), // output vel
-                ComparisonTypes_t(joint->numberDof(), Equality)),
+                ComparisonTypes_t(joint->numberDof(), Equality),
+		std::vector<bool>(joint->numberDof(), true)),
       jointName_ (joint->name ()),
       configSpace_ (joint->configurationSpace ())
     {
@@ -156,7 +157,8 @@ namespace hpp {
                                    joint->configSize()-index)), // output conf
                 list_of(segment_t (joint->rankInVelocity     (),
                                    joint->numberDof ()-index)), // output vel
-                ComparisonTypes_t(joint->numberDof()-index, Equality)),
+                ComparisonTypes_t(joint->numberDof()-index, Equality),
+		std::vector<bool>(joint->numberDof(), true)),
       jointName_ ("partial_" + joint->name ()),
       joint_ (joint),
       configSpace_ (LiegroupSpace::Rn (joint->configSize () - index))
@@ -182,7 +184,8 @@ namespace hpp {
                 list_of(segment_t (dev->numberDof ()  -
                                    dev->extraConfigSpace().dimension() + index,
                                    value.size())), // output vel
-                ComparisonTypes_t(value.size(), Equality)),
+                ComparisonTypes_t(value.size(), Equality),
+		std::vector<bool>(value.size(), true)),
       jointName_ (dev->name() + "_extraDof" + numToStr (index)),
       joint_ (JointPtr_t ()), configSpace_ (LiegroupSpace::Rn (value.size ()))
     {

--- a/src/solver/by-substitution.cc
+++ b/src/solver/by-substitution.cc
@@ -212,7 +212,7 @@ namespace hpp {
           }
           if (active){ // If at least one element of adp is true
 	    for (const segment_t s : constraints [i]->activeRows()) {
-	      rows.push_back(segment_t(s.first+row, s.second));
+	      rows.emplace_back(s.first+row, s.second);
 	    }
 	  }
           row += constraints [i]->function ().outputDerivativeSize();

--- a/src/solver/by-substitution.cc
+++ b/src/solver/by-substitution.cc
@@ -58,7 +58,7 @@ namespace hpp {
       {
         for (NumericalConstraints_t::iterator it (constraints_.begin ());
              it != constraints_.end (); ++it) {
-          assert (contains (*it));
+          //assert (contains (*it));
         }
       }
 

--- a/src/solver/by-substitution.cc
+++ b/src/solver/by-substitution.cc
@@ -210,10 +210,11 @@ namespace hpp {
               array().cast<bool>();
             active = adpF.any();
           }
-          if (active) // If at least one element of adp is true
-            rows.push_back (BlockIndices::segment_t
-                            (row, constraints [i]->function ().
-                             outputDerivativeSize()));
+          if (active){ // If at least one element of adp is true
+	    for (const segment_t s : constraints [i]->activeRows()) {
+	      rows.push_back(segment_t(s.first+row, s.second));
+	    }
+	  }
           row += constraints [i]->function ().outputDerivativeSize();
         }
         d.activeRowsOfJ = Eigen::MatrixBlocks<false,false>

--- a/src/solver/hierarchical-iterative.cc
+++ b/src/solver/hierarchical-iterative.cc
@@ -401,7 +401,7 @@ namespace hpp {
              matrix()).eval();
           if (adp.any()) // If at least one element of adp is true
 	    for (const segment_t s : constraints [i]->activeRows()) {
-	      rows.push_back(segment_t(s.first+offset, s.second));
+	      rows.emplace_back(s.first+offset, s.second);
 	    }
           offset += constraints [i]->function ().outputDerivativeSize();
         }

--- a/src/solver/hierarchical-iterative.cc
+++ b/src/solver/hierarchical-iterative.cc
@@ -846,19 +846,20 @@ namespace hpp {
           os << iendl << "Level " << i;
           if (lastIsOptional_ && i == end) os << " (optional)";
           os << ": Stack of " << constraints.size () << " functions" << incindent;
-          size_type row = 0;
+          size_type rv = 0, rq = 0;
           for (std::size_t j = 0; j < constraints.size (); ++j) {
             const DifferentiableFunctionPtr_t& f
               (constraints [j]->functionPtr ());
             os << iendl << j << ": ["
-               << row << ", " << f->outputDerivativeSize() << "],"
+               << rv << ", " << f->outputDerivativeSize() << "],"
                << incindent << *f
                << iendl << "Rhs: " << condensed(d.rightHandSide.vector().segment
-                                                (row, f->outputSize()))
+                                                (rq, f->outputSize()))
 	       << iendl << "active rows: "
 	       << condensed(constraints[j]->activeRows())
                << decindent;
-            row += f->outputDerivativeSize();
+            rv += f->outputDerivativeSize();
+            rq += f->outputSize();
           }
           os << decendl;
           os << "Equality idx: " << d.equalityIndices;

--- a/src/solver/hierarchical-iterative.cc
+++ b/src/solver/hierarchical-iterative.cc
@@ -419,9 +419,9 @@ namespace hpp {
           ics.function ().value (d.output, config);
           d.error.setZero();
           d.equalityIndices.lview(d.error) =
-            d.equalityIndices.rview(d.output - d.rightHandSide);
+            d.equalityIndices.rview(log(d.output));
           // rhs = exp (error)
-          d.rightHandSide += d.error;
+          d.rightHandSide = d.rightHandSide.space()->exp(d.error);
         }
         return rightHandSide();
       }

--- a/tests/convex-shape-contact.cc
+++ b/tests/convex-shape-contact.cc
@@ -227,8 +227,10 @@ BOOST_AUTO_TEST_CASE(convexShapeContact)
         q1.vector() = q.head<7>();
         q2.vector() = q.tail<7>();
         q1Invq2 = SE3->exp(q2-q1);
+	// Note that error of constraint is not equivalent to relative
+	// position between objects, but between contact surface frames.
         BOOST_CHECK ((q1Invq2-q1Invq2Exp[j]).norm() <=
-                     solver2.errorThreshold());
+                     10 * solver2.errorThreshold());
       }
       else
       {

--- a/tests/explicit-constraint-set.cc
+++ b/tests/explicit-constraint-set.cc
@@ -641,7 +641,7 @@ BOOST_AUTO_TEST_CASE(RelativePose)
   hpp::constraints::ExplicitPtr_t constraint
     (hpp::constraints::explicit_::RelativePose::create
      ("explicit-relative-pose", device, joint1, joint2, frame1, frame2,
-      6 * Equality));
+      6 * Equality, std::vector<bool>(6,true)));
   assert(constraint->inputConf().size() == 1);
   assert(constraint->inputConf()[0].first == 0);
   assert(constraint->inputConf()[0].second == 7);

--- a/tests/explicit-constraint-set.cc
+++ b/tests/explicit-constraint-set.cc
@@ -632,8 +632,8 @@ BOOST_AUTO_TEST_CASE(RelativePose)
   // Set joint bounds
   hpp::pinocchio::JointPtr_t joint1 (device->jointAt(0));
   hpp::pinocchio::JointPtr_t joint2 (device->jointAt(1));
-  vector_t low (device->configSize()); low.fill(-0.0001);
-  vector_t  up (device->configSize());  up.fill( 0.0001);
+  vector_t low (device->configSize()); low.fill(-1);
+  vector_t  up (device->configSize());  up.fill( 1);
 
   hpp::constraints::Transform3f frame1(pinocchio::SE3::Random());
   hpp::constraints::Transform3f frame2(pinocchio::SE3::Random());
@@ -675,22 +675,18 @@ BOOST_AUTO_TEST_CASE(RelativePose)
       // Get value of function h for new value of q -> rhs2_impl
       LiegroupElement rhs2_impl (constraint->function().outputSpace());
       constraint->function().value(rhs2_impl, q);
-      std::cout << "            \t";
-      for (size_type j=0; j < (size_type)comp.size(); ++j) {
-        std::cout << (comp[j] == Equality ? " = \t" :
-                      " =0\t");
-      }
-      std::cout << std::endl;
-      std::cout << "rhs0_impl = " << rhs0_impl.vector().transpose() << std::endl;
-      std::cout << "rhs2_impl = " << rhs2_impl.vector().transpose() << std::endl;
+      vector_t logRhs0_impl = log(rhs0_impl);
+      vector_t logRhs2_impl = log(rhs2_impl);
+      assert(logRhs0_impl.size()==6);
+      assert(logRhs2_impl.size()==6);
       // For each coordinate check that
       // rhs2_impl [j] == 0 if comp[i] is EqualToZero
       // rhs2_impl [j] == rhs0_impl [j] if comp[i] is Equality
       for (size_type j=0; j<6; ++j){
         BOOST_CHECK(((comp[j] == EqualToZero) &&
-                     (fabs(rhs2_impl.vector()[j]) < 1e-10))
+                     (fabs(logRhs2_impl[j]) < 1e-10))
                     || ((comp[j] == Equality) &&
-                        (fabs(rhs2_impl.vector()[j] - rhs0_impl.vector()[j])
+                        (fabs(logRhs2_impl[j] - logRhs0_impl[j])
                          < 1e-10)));
       }
     }

--- a/tests/generic-transformation.cc
+++ b/tests/generic-transformation.cc
@@ -239,7 +239,7 @@ BOOST_AUTO_TEST_CASE (serialization) {
   }
 }
 
-BOOST_AUTO_TEST_CASE(RelativeTransformation_SE3)
+BOOST_AUTO_TEST_CASE(RelativeTransformation_R3xSO3)
 {
   const std::string model("<robot name=\"box\">"
                           "  <link name=\"baselink\">"

--- a/tests/generic-transformation.cc
+++ b/tests/generic-transformation.cc
@@ -295,8 +295,8 @@ BOOST_AUTO_TEST_CASE(RelativeTransformation_SE3)
   Transform3f tf1(R1, p1), tf2(R2,p2);
   std::vector<bool> mask = {false, false, false, false, false, true};
   ImplicitPtr_t constraint
-    (Implicit::create (RelativeTransformationSE3::create
-		       ("RelativeTransformationSE3", robot, j1, j2,
+    (Implicit::create (RelativeTransformationR3xSO3::create
+		       ("RelativeTransformationR3xSO3", robot, j1, j2,
 			tf1, tf2),
 		       6 * Equality, mask));
   BasicConfigurationShooter cs (robot);
@@ -316,8 +316,8 @@ BOOST_AUTO_TEST_CASE(RelativeTransformation_SE3)
 
   // Create grasp constraint with one degree of freedom in rotation along z
   mask = {true, true, true, true, true, false};
-  ImplicitPtr_t c1 (Implicit::create(RelativeTransformationSE3::create
-				     ("RelativeTransformationSE3", robot,
+  ImplicitPtr_t c1 (Implicit::create(RelativeTransformationR3xSO3::create
+				     ("RelativeTransformationR3xSO3", robot,
 				      j1, j2, tf1, tf2), 6*EqualToZero, mask));
   solver::BySubstitution s1(robot->configSpace());
   s1.errorThreshold(1e-10);

--- a/tests/solver-by-substitution.cc
+++ b/tests/solver-by-substitution.cc
@@ -821,7 +821,7 @@ BOOST_AUTO_TEST_CASE(hybrid_solver_rhs)
   Configuration_t q, qrand;
 
   JointPtr_t left = device->getJointByName ("LWristPitch");
-  TransformationSE3::Ptr_t frame (TransformationSE3::create
+  TransformationR3xSO3::Ptr_t frame (TransformationR3xSO3::create
       ("LWristPitch", device, left, Transform3f::Identity()));
   Transformation::Ptr_t logFrame (Transformation::create
       ("LWristPitch", device, left, Transform3f::Identity()));
@@ -852,7 +852,7 @@ BOOST_AUTO_TEST_CASE(hybrid_solver_rhs)
     EIGEN_IS_APPROX (expectedJlogFrame, JlogFrame);
   }
 
-  // Check that the solver can handle constraints with SE3 outputs.
+  // Check that the solver can handle constraints with R3xSO3 outputs.
   ImplicitPtr_t constraint (Implicit::create (frame, 6 * Equality));
 
   BySubstitution solver(device->configSpace ());

--- a/tests/solver-by-substitution.cc
+++ b/tests/solver-by-substitution.cc
@@ -959,9 +959,13 @@ BOOST_AUTO_TEST_CASE (rightHandSideFromConfig)
   assert(comp1 [0] ==  EqualToZero);
   assert(comp1 [2] ==  EqualToZero);
   assert(comp1 [4] == EqualToZero);
-  ComparisonTypes_t comp2(Equality<<EqualToZero<<EqualToZero<<3*Equality);
-  assert(comp2 [1] == EqualToZero);
+  ComparisonTypes_t comp2(2*Equality<<2*EqualToZero<<2*Equality);
+  assert(comp2 [0] == Equality);
+  assert(comp2 [1] == Equality);
   assert(comp2 [2] == EqualToZero);
+  assert(comp2 [3] == EqualToZero);
+  assert(comp2 [4] == Equality);
+  assert(comp2 [5] == Equality);
   // Create two relative transformation constraints
   Transform3f tf1 (Transform3f::Identity());
   vector3_t u; u << 0, -.2, 0;
@@ -995,6 +999,7 @@ BOOST_AUTO_TEST_CASE (rightHandSideFromConfig)
   //           rhs [9]
   //           rhs [10]
   //           rhs [11]
+  //           rhs [12]
   for (size_type i=0; i<1000; ++i) {
     Configuration_t q (device->configSize ()); q.setRandom ();
     bool success;
@@ -1006,8 +1011,8 @@ BOOST_AUTO_TEST_CASE (rightHandSideFromConfig)
     // Store right hand side for each constraint
     vector_t rhs1 (6); rhs1.setZero ();
     vector_t rhs1_ (6); rhs1_.setZero ();
-    vector_t rhs2 (6); rhs2.setZero ();
-    vector_t rhs2_ (6); rhs2_.setZero ();
+    vector_t rhs2 (7); rhs2.setZero ();
+    vector_t rhs2_ (7); rhs2_.setZero ();
     success = solver.getRightHandSide (c1, rhs1);
     BOOST_CHECK (success);
     success = solver.getRightHandSide (c2, rhs2);
@@ -1028,8 +1033,8 @@ BOOST_AUTO_TEST_CASE (rightHandSideFromConfig)
     BOOST_CHECK (success);
     success = solver.getRightHandSide (c2, rhs2_);
     BOOST_CHECK (success);
-    BOOST_CHECK_EQUAL (rhs1, rhs1_);
-    BOOST_CHECK_EQUAL (rhs2, rhs2_);
+    BOOST_CHECK ((rhs1 - rhs1_).norm() < 1e-10);
+    BOOST_CHECK ((rhs2 - rhs2_).norm() < 1e-10);
   }
 }
 

--- a/tests/solver-by-substitution.cc
+++ b/tests/solver-by-substitution.cc
@@ -979,7 +979,7 @@ BOOST_AUTO_TEST_CASE (rightHandSideFromConfig)
   tf2.translation (u);
   ImplicitPtr_t c2 (hpp::constraints::explicit_::RelativePose::create
                     ("Transformation", device, JointPtr_t (), root, tf2, tf1,
-                     comp2));
+                     comp2, std::vector<bool>(6, true)));
 
   BySubstitution solver (device->configSpace ());
   solver.maxIterations(20);
@@ -1057,7 +1057,7 @@ BOOST_AUTO_TEST_CASE (merge)
   Transform3f tf2 (Transform3f::Identity()); tf2.translation (u);
   DifferentiableFunctionPtr_t h
     (RelativeTransformation::create("RelativeTransformation",device, ee1, ee2,
-                                    tf1, tf2, std::vector <bool> (6, true)));
+                                    tf1, tf2));
   ImplicitPtr_t c1 (Implicit::create(h, comp1));
   u << 1.2, 0, -1;
   tf2.translation (u);

--- a/tests/test-jacobians.cc
+++ b/tests/test-jacobians.cc
@@ -180,7 +180,7 @@ BOOST_AUTO_TEST_CASE (jacobian) {
   functions.push_back (
       RelativeTransformation::create ("RelativeTransformation", device, ee1, ee2, tf1, tf2));
   functions.push_back (
-      RelativeTransformationSE3::create ("RelativeTransformationSE3", device, ee1, ee2, tf1, tf2));
+      RelativeTransformationR3xSO3::create ("RelativeTransformationR3xSO3", device, ee1, ee2, tf1, tf2));
   functions.push_back (
       createConvexShapeContact_triangles (device, ee1, "ConvexShapeContact triangle"));
   functions.push_back (

--- a/tests/test-jacobians.cc
+++ b/tests/test-jacobians.cc
@@ -176,11 +176,12 @@ BOOST_AUTO_TEST_CASE (jacobian) {
   functions.push_back (
       Transformation::create ("Transformation", device, ee1, tf1));
   functions.push_back (
-      TransformationSE3::create ("TransformationSE3", device, ee1, tf1));
+      TransformationR3xSO3::create ("TransformationR3xSO3", device, ee1, tf1));
   functions.push_back (
       RelativeTransformation::create ("RelativeTransformation", device, ee1, ee2, tf1, tf2));
   functions.push_back (
-      RelativeTransformationR3xSO3::create ("RelativeTransformationR3xSO3", device, ee1, ee2, tf1, tf2));
+      RelativeTransformationR3xSO3::create
+      ("RelativeTransformationR3xSO3", device, ee1, ee2, tf1, tf2));
   functions.push_back (
       createConvexShapeContact_triangles (device, ee1, "ConvexShapeContact triangle"));
   functions.push_back (


### PR DESCRIPTION
Solver now handle constraints in Lie groups.
typedef RelativeTransformationR3xSO3 compute the relative position between two frames as an element of R3xSO(3).