### PR TITLE
Fix ConvexShapeContactComplement

### DIFF
--- a/include/hpp/constraints/matrix-view.hh
+++ b/include/hpp/constraints/matrix-view.hh
@@ -580,6 +580,14 @@ namespace Eigen {
             YOU_MIXED_MATRICES_OF_DIFFERENT_SIZES);
       }
 
+      MatrixBlocks& operator=(const MatrixBlocks& other)
+      {
+        m_nbRows = other.m_nbRows;
+        m_nbCols = other.m_nbCols;
+        m_rows = other.m_rows;
+        m_cols = other.m_cols;
+        return *this;
+      }
       /// Clear rows
       inline void clearRows ()
       {

--- a/src/explicit/convex-shape-contact.cc
+++ b/src/explicit/convex-shape-contact.cc
@@ -167,7 +167,8 @@ namespace hpp {
             pose_.push_back(RelativePose::create
                             ("",robot, fs[j].joint_, os[i].joint_,
                              posInJoint, os[i].positionInJoint(),
-                             6 * Equality, std::vector<bool>(6, true)));
+                             EqualToZero << 3 * Equality << 2 * EqualToZero,
+                             std::vector<bool>(6, true)));
           }
         }
       }


### PR DESCRIPTION
  - Use correct comparison types in explicit_::RelativePose instances stored in class ConvexShapeContactComplement.
  - add operator= in MatrixView to suppress a compilation warning.