### PR TITLE
Implement DifferentiableFunction equality to avoir comparing pointer

### DIFF
--- a/include/hpp/constraints/active-set-differentiable-function.hh
+++ b/include/hpp/constraints/active-set-differentiable-function.hh
@@ -83,6 +83,19 @@ namespace hpp {
             jacobian.middleCols (_int->first, _int->second).setZero ();
         }
 
+        bool isEqual(const DifferentiableFunction& other) const {
+          const ActiveSetDifferentiableFunction& castother = dynamic_cast<const ActiveSetDifferentiableFunction&>(other);
+          if (!DifferentiableFunction::isEqual(other))
+            return false;
+          
+          if (function_ != castother.function_)
+            return false;
+          if (intervals_ != castother.intervals_)
+            return false;
+          
+          return true;
+        }
+
         DifferentiableFunctionPtr_t function_;
         segments_t intervals_;
     }; // class ActiveSetDifferentiableFunction

--- a/include/hpp/constraints/affine-function.hh
+++ b/include/hpp/constraints/affine-function.hh
@@ -56,6 +56,14 @@ namespace hpp {
           J.setIdentity();
         }
 
+        bool isEqual(const DifferentiableFunction& other) const {
+          dynamic_cast<const Identity&>(other);
+          if (!DifferentiableFunction::isEqual(other))
+            return false;
+
+          return true;
+        }
+
       private:
         Identity() {}
         HPP_SERIALIZABLE();
@@ -98,6 +106,19 @@ namespace hpp {
           J_ (J), b_ (b)
         {
           init();
+        }
+
+        bool isEqual(const DifferentiableFunction& other) const {
+          const AffineFunction& castother = dynamic_cast<const AffineFunction&>(other);
+          if (!DifferentiableFunction::isEqual(other))
+            return false;
+          
+          if (J_ != castother.J_)
+            return false;
+          if (b_ != castother.b_)
+            return false;
+          
+          return true;
         }
 
       private:
@@ -170,6 +191,17 @@ namespace hpp {
         void impl_compute (LiegroupElementRef r, vectorIn_t) const { r = c_; }
 
         void impl_jacobian (matrixOut_t J, vectorIn_t) const { J.setZero(); }
+
+        bool isEqual(const DifferentiableFunction& other) const {
+          const ConstantFunction& castother = dynamic_cast<const ConstantFunction&>(other);
+          if (!DifferentiableFunction::isEqual(other))
+            return false;
+          
+          if (c_.vector() == castother.c_.vector())
+            return false;
+          
+          return true;
+        }
 
         const LiegroupElement c_;
 

--- a/include/hpp/constraints/com-between-feet.hh
+++ b/include/hpp/constraints/com-between-feet.hh
@@ -94,6 +94,34 @@ namespace hpp {
 
         virtual void impl_jacobian (matrixOut_t jacobian,
             ConfigurationIn_t arg) const;
+
+        bool isEqual(const DifferentiableFunction& other) const {
+          const ComBetweenFeet& castother = dynamic_cast<const ComBetweenFeet&>(other);
+          if (!DifferentiableFunction::isEqual(other))
+            return false;
+          
+          if (robot_ != castother.robot_)
+            return false;
+          if (com_->centerOfMassComputation() != castother.com_->centerOfMassComputation())
+            return false;
+          if (left_->joint() != castother.left_->joint())
+            return false;
+          if (right_->joint() != castother.right_->joint())
+            return false;
+          if (left_->local() != castother.left_->local())
+            return false;
+          if (right_->local() != castother.right_->local())
+            return false;
+          if (jointRef_ != castother.jointRef_)
+            return false;
+          if (pointRef_ != castother.pointRef_)
+            return false;
+          if (mask_ != castother.mask_)
+            return false;
+          
+          return true;
+        }
+
       private:
         DevicePtr_t robot_;
         mutable Traits<PointCom>::Ptr_t com_;

--- a/include/hpp/constraints/configuration-constraint.hh
+++ b/include/hpp/constraints/configuration-constraint.hh
@@ -72,12 +72,27 @@ namespace hpp {
             ConfigurationIn_t arg) const;
 
         std::ostream& print (std::ostream& o) const;
+
+        bool isEqual(const DifferentiableFunction& other) const {
+          const ConfigurationConstraint& castother = dynamic_cast<const ConfigurationConstraint&>(other);
+          if (!DifferentiableFunction::isEqual(other))
+            return false;
+          
+          if (robot_ != castother.robot_)
+            return false;
+          if (goal_.vector() != castother.goal_.vector())
+            return false;
+          if (weights_ != castother.weights_)
+            return false;
+          
+          return true;
+        }
       private:
         typedef Eigen::Array <bool, Eigen::Dynamic, 1> EigenBoolVector_t;
         DevicePtr_t robot_;
         LiegroupElement goal_;
         vector_t weights_;
-    }; // class ComBetweenFeet
+    }; // class ConfigurationConstraint
   } // namespace constraints
 } // namespace hpp
 #endif // HPP_CONSTRAINTS_CONFIGURATION_CONSTRAINT_HH

--- a/include/hpp/constraints/convex-shape-contact.hh
+++ b/include/hpp/constraints/convex-shape-contact.hh
@@ -154,6 +154,21 @@ namespace hpp {
                           const JointAndShapes_t& floorSurfaces,
                           const JointAndShapes_t& objectSurfaces);
 
+      bool isEqual(const DifferentiableFunction& other) const {
+        const ConvexShapeContact& castother = dynamic_cast<const ConvexShapeContact&>(other);
+        if (!DifferentiableFunction::isEqual(other))
+          return false;
+        
+        if (robot_ != castother.robot_)
+          return false;
+        if (objectConvexShapes_.size() != castother.objectConvexShapes_.size())
+          return false;
+        for (std::size_t i = 0; i < objectConvexShapes_.size(); i++)
+          if (floorConvexShapes_[i] != castother.floorConvexShapes_[i])
+            return false;
+        
+        return true;
+      }
 
       private:
         /// Add a ConvexShape as an object.
@@ -255,7 +270,12 @@ namespace hpp {
                                     const JointAndShapes_t& floorSurfaces,
                                     const JointAndShapes_t& objectSurfaces);
 
-
+      bool isEqual(const DifferentiableFunction& other) const {
+        const ConvexShapeContactComplement& castother = dynamic_cast<const ConvexShapeContactComplement&>(other);
+        if (!DifferentiableFunction::isEqual(other))
+          return false;
+        return (sibling_ != castother.sibling_);
+      }
     private:
       void impl_compute (LiegroupElementRef result, ConfigurationIn_t argument) const;
 
@@ -314,6 +334,19 @@ namespace hpp {
         const;
       virtual void impl_jacobian(matrixOut_t jacobian, vectorIn_t arg)
         const;
+
+      bool isEqual(const DifferentiableFunction& other) const {
+        const ConvexShapeContactHold& castother = dynamic_cast<const ConvexShapeContactHold&>(other);
+        if (!DifferentiableFunction::isEqual(other))
+          return false;
+        
+        if (constraint_ != castother.constraint_)
+          return false;
+        if (complement_ != castother.complement_)
+          return false;
+        
+        return true;
+      }
     private:
       ConvexShapeContactPtr_t constraint_;
       ConvexShapeContactComplementPtr_t complement_;

--- a/include/hpp/constraints/convex-shape.hh
+++ b/include/hpp/constraints/convex-shape.hh
@@ -156,6 +156,21 @@ namespace hpp {
         /// Transform of the shape in the joint frame
         inline const Transform3f& positionInJoint () const { return MinJoint_; }
 
+        bool operator==(ConvexShape const & other) const {
+          if (Pts_ != other.Pts_) return false;
+          if (shapeDimension_ != other.shapeDimension_) return false;
+          if (C_ != other.C_) return false;
+          if (N_ != other.N_) return false;
+          if (Ns_ != other.Ns_) return false;
+          if (Us_ != other.Us_) return false;
+          if (Ls_ != other.Ls_) return false;
+          if (MinJoint_ != other.MinJoint_) return false;
+          if (joint_ != other.joint_) return false;
+        }
+        bool operator!=(ConvexShape const & other) const {
+          return !(this->operator==(other));
+        }
+
         /// The points in the joint frame. It is constant.
         std::vector <vector3_t> Pts_;
         size_t shapeDimension_;

--- a/include/hpp/constraints/differentiable-function-set.hh
+++ b/include/hpp/constraints/differentiable-function-set.hh
@@ -126,6 +126,23 @@ namespace hpp {
             row += f.outputDerivativeSize();
           }
         }
+
+        bool isEqual(const DifferentiableFunction& other) const {
+          const DifferentiableFunctionSet& castother = dynamic_cast<const DifferentiableFunctionSet&>(other);
+          if (!DifferentiableFunction::isEqual(other))
+            return false;
+          
+          if (functions_ != castother.functions_)
+            return false;
+          if (result_.size() != castother.result_.size())
+            return false;
+          for (std::size_t i=0; i<result_.size(); i++)
+            if (result_[i] != castother.result_[i])
+              return false;
+          
+          return true; 
+        }
+
       private:
         Functions_t functions_;
         mutable std::vector <LiegroupElement> result_;

--- a/include/hpp/constraints/distance-between-bodies.hh
+++ b/include/hpp/constraints/distance-between-bodies.hh
@@ -92,6 +92,23 @@ namespace hpp {
 				 ConfigurationIn_t argument) const;
       virtual void impl_jacobian (matrixOut_t jacobian,
 				  ConfigurationIn_t arg) const;
+
+      bool isEqual(const DifferentiableFunction& other) const {
+        const DistanceBetweenBodies& castother = dynamic_cast<const DistanceBetweenBodies&>(other);
+        if (!DifferentiableFunction::isEqual(other))
+          return false;
+        
+        if (robot_ != castother.robot_)
+          return false;
+        if (joint1_ != castother.joint1_)
+          return false;
+        if (joint2_ != castother.joint2_)
+          return false;
+        if (data_ != castother.data_)
+          return false;
+        
+        return true;
+      }
     private:
       typedef ::pinocchio::GeometryData GeometryData;
 

--- a/include/hpp/constraints/distance-between-points-in-bodies.hh
+++ b/include/hpp/constraints/distance-between-points-in-bodies.hh
@@ -95,6 +95,25 @@ namespace hpp {
 				 ConfigurationIn_t argument) const;
       virtual void impl_jacobian (matrixOut_t jacobian,
 				  ConfigurationIn_t arg) const;
+
+      bool isEqual(const DifferentiableFunction& other) const {
+        const DistanceBetweenPointsInBodies& castother = dynamic_cast<const DistanceBetweenPointsInBodies&>(other);
+        if (!DifferentiableFunction::isEqual(other))
+          return false;
+        
+        if (robot_ != castother.robot_)
+          return false;
+        if (joint1_ != castother.joint1_)
+          return false;
+        if (joint2_ != castother.joint2_)
+          return false;
+        if (point1_ != castother.point1_)
+          return false;
+        if (point2_ != castother.point2_)
+          return false;
+        
+        return true;
+      }
     private:
       DevicePtr_t robot_;
       JointPtr_t joint1_;

--- a/include/hpp/constraints/explicit.hh
+++ b/include/hpp/constraints/explicit.hh
@@ -248,6 +248,8 @@ namespace hpp {
 
       /// Copy constructor
       Explicit (const Explicit& other);
+      
+      bool isEqual (const Implicit& other, bool swapAndTest) const;
 
       // Store weak pointer to itself
       void init (const ExplicitWkPtr_t& weak);

--- a/include/hpp/constraints/explicit/implicit-function.hh
+++ b/include/hpp/constraints/explicit/implicit-function.hh
@@ -79,6 +79,27 @@ namespace hpp {
       /// Compute Jacobian of g (q_out) - f (q_in) with respect to q.
       void impl_jacobian (matrixOut_t jacobian, vectorIn_t arg) const;
 
+      bool isEqual(const DifferentiableFunction& other) const {
+        const ImplicitFunction& castother = dynamic_cast<const ImplicitFunction&>(other);
+        if (!DifferentiableFunction::isEqual(other))
+          return false;
+        
+        if (robot_ != castother.robot_)
+          return false;
+        if (inputToOutput_ != castother.inputToOutput_)
+          return false;
+        if (inputConfIntervals_.rows() != castother.inputConfIntervals_.rows())
+          return false;
+        if (outputConfIntervals_.rows() != castother.outputConfIntervals_.rows())
+          return false;
+        if (inputDerivIntervals_.rows() != castother.inputDerivIntervals_.rows())
+          return false;
+        if (outputDerivIntervals_.rows() != castother.outputDerivIntervals_.rows())
+          return false;
+
+        return true;
+      }
+
     private:
       void computeJacobianBlocks ();
 

--- a/include/hpp/constraints/explicit/relative-transformation.hh
+++ b/include/hpp/constraints/explicit/relative-transformation.hh
@@ -112,6 +112,37 @@ namespace hpp {
 
       void impl_jacobian (matrixOut_t jacobian, vectorIn_t arg) const;
 
+      bool isEqual(const DifferentiableFunction& other) const {
+        const RelativeTransformation& castother = dynamic_cast<const RelativeTransformation&>(other);
+        if (!DifferentiableFunction::isEqual(other))
+          return false;
+        
+        if (robot_ != castother.robot_)
+          return false;
+        if (parentJoint_ != castother.parentJoint_)
+          return false;
+        if (joint1_ != castother.joint1_)
+          return false;
+        if (joint2_ != castother.joint2_)
+          return false;
+        if (frame1_ != castother.frame1_)
+          return false;
+        if (frame2_ != castother.frame2_)
+          return false;
+        if (inConf_.rows() != castother.inConf_.rows())
+          return false;
+        if (inVel_.cols() != castother.inVel_.cols())
+          return false;
+        if (outConf_.rows() != castother.outConf_.rows())
+          return false;
+        if (outVel_.rows() != castother.outVel_.rows())
+          return false;
+        if (F1inJ1_invF2inJ2_ != castother.F1inJ1_invF2inJ2_)
+          return false;
+        
+        return true;
+      }
+
     private:
       void forwardKinematics (vectorIn_t arg) const;
 

--- a/include/hpp/constraints/function/difference.hh
+++ b/include/hpp/constraints/function/difference.hh
@@ -58,6 +58,25 @@ namespace hpp {
           J.middleCols (rsd_.first, rsd_.second) *= -1;
         }
 
+        bool isEqual(const DifferentiableFunction& other) const {
+          const Difference& castother = dynamic_cast<const Difference&>(other);
+          if (!DifferentiableFunction::isEqual(other))
+            return false;
+          
+          if (inner_ != castother.inner_)
+            return false;
+          if (lsa_ != castother.lsa_)
+            return false;
+          if (lsd_ != castother.lsd_)
+            return false;
+          if (rsa_ != castother.rsa_)
+            return false;
+          if (rsd_ != castother.rsd_)
+            return false;
+          
+          return true;
+        }
+
         std::ostream& print (std::ostream& os) const;
 
         DifferentiableFunctionPtr_t inner_;

--- a/include/hpp/constraints/function/of-parameter-subset.hh
+++ b/include/hpp/constraints/function/of-parameter-subset.hh
@@ -79,6 +79,21 @@ namespace hpp {
                            arg.segment (sa_.first, sa_.second));
         }
 
+        bool isEqual(const DifferentiableFunction& other) const {
+          const OfParameterSubset& castother = dynamic_cast<const OfParameterSubset&>(other);
+          if (!DifferentiableFunction::isEqual(other))
+            return false;
+          
+          if (g_ != castother.g_)
+            return false;
+          if (sa_ != castother.sa_)
+            return false;
+          if (sd_ != castother.sd_)
+            return false;
+          
+          return true;
+        }
+
         std::ostream& print (std::ostream& os) const;
 
         DifferentiableFunctionPtr_t g_;

--- a/include/hpp/constraints/generic-transformation.hh
+++ b/include/hpp/constraints/generic-transformation.hh
@@ -309,6 +309,19 @@ namespace hpp {
 				 ConfigurationIn_t argument) const;
       virtual void impl_jacobian (matrixOut_t jacobian,
 				  ConfigurationIn_t arg) const;
+
+      bool isEqual(const DifferentiableFunction& other) const {
+        const GenericTransformation& castother = dynamic_cast<const GenericTransformation&>(other);
+        if (!DifferentiableFunction::isEqual(other))
+          return false;
+        if (robot_ != castother.robot_)
+          return false;
+        if (mask_ != castother.mask_)
+          return false;
+        
+        return true;
+      }
+
     private:
       void computeActiveParams ();
       DevicePtr_t robot_;

--- a/include/hpp/constraints/manipulability.hh
+++ b/include/hpp/constraints/manipulability.hh
@@ -55,6 +55,25 @@ namespace hpp {
 
       void impl_jacobian (matrixOut_t jacobian, vectorIn_t arg) const;
 
+      bool isEqual(const DifferentiableFunction& other) const {
+        const Manipulability& castother = dynamic_cast<const Manipulability&>(other);
+        if (!DifferentiableFunction::isEqual(other))
+          return false;
+        
+        if (function_ != castother.function_)
+          return false;
+        if (robot_ != castother.robot_)
+          return false;
+        if (cols_.cols() != castother.cols_.cols())
+          return false;
+        if (J_ != castother.J_)
+          return false;
+        if (J_JT_ != castother.J_JT_)
+          return false;
+        
+        return true;
+      }
+
     private:
       DifferentiableFunctionPtr_t function_;
       DevicePtr_t robot_;

--- a/include/hpp/constraints/qp-static-stability.hh
+++ b/include/hpp/constraints/qp-static-stability.hh
@@ -72,7 +72,27 @@ namespace hpp {
         MatrixOfExpressions<>& phi () {
           return phi_;
         }
-
+      protected:
+        bool isEqual(const DifferentiableFunction& other) const {
+          const QPStaticStability& castother = dynamic_cast<const QPStaticStability&>(other);
+          if (!DifferentiableFunction::isEqual(other))
+            return false;
+          
+          if (name_ != castother.name_)
+            return false;
+          if (robot_ != castother.robot_)
+            return false;
+          if (nbContacts_ != castother.nbContacts_)
+            return false;
+          if (com_ != castother.com_)
+            return false;
+          if (Zeros != castother.Zeros)
+            return false;
+          if (nWSR != castother.nWSR)
+            return false;
+          
+          return true;
+        }
       private:
         static const Eigen::Matrix <value_type, 6, 1> MinusGravity;
 

--- a/include/hpp/constraints/relative-com.hh
+++ b/include/hpp/constraints/relative-com.hh
@@ -97,6 +97,25 @@ namespace hpp {
 	const;
       virtual void impl_jacobian (matrixOut_t jacobian,
 				  ConfigurationIn_t arg) const;
+
+      bool isEqual(const DifferentiableFunction& other) const {
+        const RelativeCom& castother = dynamic_cast<const RelativeCom&>(other);
+        if (!DifferentiableFunction::isEqual(other))
+          return false;
+        
+        if (robot_ != castother.robot_)
+          return false;
+        if (comc_ != castother.comc_)
+          return false;
+        if (joint_ != castother.joint_)
+          return false;
+        if (mask_ != castother.mask_)
+          return false;
+        if (nominalCase_ != castother.nominalCase_)
+          return false;
+        
+        return true;
+      }
     private:
       DevicePtr_t robot_;
       CenterOfMassComputationPtr_t comc_;

--- a/include/hpp/constraints/solver/by-substitution.hh
+++ b/include/hpp/constraints/solver/by-substitution.hh
@@ -152,7 +152,7 @@ namespace hpp {
         /// J^{+}J(\textbf{q}_{from})\right) (\textbf{v})
         /// \f]
         void projectVectorOnKernel (ConfigurationIn_t from, vectorIn_t velocity,
-                                    ConfigurationOut_t result) const;
+                                    vectorOut_t result) const;
 
         /// Project configuration "to" on constraint tangent space in "from"
         ///

--- a/include/hpp/constraints/static-stability.hh
+++ b/include/hpp/constraints/static-stability.hh
@@ -41,6 +41,15 @@ namespace hpp {
           JointPtr_t joint1, joint2;
           vector3_t point1, point2;
           vector3_t normal1, normal2;
+          bool operator==(Contact_t const& other) const {
+            if (joint1 != other.joint1) return false;
+            if (joint2 != other.joint2) return false;
+            if (point1 != other.point1) return false;
+            if (point2 != other.point2) return false;
+            if (normal1 != other.normal1) return false;
+            if (normal2 != other.normal2) return false;
+            return true;
+          }
         };
         typedef std::vector <Contact_t> Contacts_t;
 
@@ -66,6 +75,21 @@ namespace hpp {
           return phi_;
         }
 
+      protected:
+        bool isEqual(const DifferentiableFunction& other) const {
+          const StaticStability& castother = dynamic_cast<const StaticStability&>(other);
+          if (!DifferentiableFunction::isEqual(other))
+            return false;
+          
+          if (robot_ != castother.robot_)
+            return false;
+          if (contacts_ != castother.contacts_)
+            return false;
+          if (com_ != castother.com_)
+            return false;
+          
+          return true;
+        }
       private:
         void impl_compute (LiegroupElementRef result,
                            ConfigurationIn_t argument) const;

--- a/include/hpp/constraints/symbolic-function.hh
+++ b/include/hpp/constraints/symbolic-function.hh
@@ -149,12 +149,27 @@ namespace hpp {
         void init (const Ptr_t& self) {
           wkPtr_ = self;
         }
+
+        bool isEqual(const DifferentiableFunction& other) const {
+          const SymbolicFunction& castother = dynamic_cast<const SymbolicFunction&>(other);
+          if (!DifferentiableFunction::isEqual(other))
+            return false;
+          
+          if (robot_ != castother.robot_)
+            return false;
+          if (expr_ != castother.expr_)
+            return false;
+          if (mask_ != castother.mask_)
+            return false;
+          
+          return true;
+        }
       private:
         WkPtr_t wkPtr_;
         DevicePtr_t robot_;
         typename Traits<Expression>::Ptr_t expr_;
         std::vector <bool> mask_;
-    }; // class ComBetweenFeet
+    }; // class SymbolicFunction
   } // namespace constraints
 } // namespace hpp
 #endif // HPP_CONSTRAINTS_SYMBOLIC_FUNCTION_HH

--- a/src/explicit-constraint-set.cc
+++ b/src/explicit-constraint-set.cc
@@ -104,7 +104,8 @@ namespace hpp {
       constraintFound = false;
       for(std::size_t i = 0; i < data_.size(); ++i) {
         const Data& d (data_[i]);
-        if (d.constraint->functionPtr () == constraint->functionPtr ()) {
+        if (d.constraint->functionPtr () == constraint->functionPtr () ||
+            d.constraint->function () == constraint->function ()) {
           const DifferentiableFunction& h (d.constraint->function ());
           h.value (d.h_value, arg);
           assert (error.size () == h.outputSpace ()->nv ());
@@ -255,7 +256,9 @@ namespace hpp {
       for (std::vector<Data>::const_iterator it = data_.begin ();
            it != data_.end (); ++it) {
         if ((it->constraint == numericalConstraint) ||
-            (*(it->constraint) == *numericalConstraint)) return true;
+            (*(it->constraint) == *numericalConstraint) ||
+            (*(it->constraint->functionPtr()) == *numericalConstraint->functionPtr()))
+          return true;
       }
       return false;
     }
@@ -341,7 +344,8 @@ namespace hpp {
     {
       for (std::size_t i = 0; i < data_.size (); ++i) {
         Data& d = data_[i];
-        if ((d.constraint == constraint) || (*d.constraint == *constraint)) {
+        if ((d.constraint == constraint) || (*d.constraint == *constraint)
+            || d.constraint->function() == constraint->function()) {
           rightHandSideFromInput (i, arg);
           return true;
         }
@@ -394,7 +398,8 @@ namespace hpp {
     {
       for (std::size_t i = 0; i < data_.size (); ++i) {
         Data& d = data_[i];
-        if ((d.constraint == constraint) || (*d.constraint == *constraint)) {
+        if ((d.constraint == constraint) || (*d.constraint == *constraint)
+          || d.constraint->function() == constraint->function()) {
           rightHandSide (i, rhs);
           return true;
         }
@@ -406,7 +411,8 @@ namespace hpp {
     {
       for (std::size_t i = 0; i < data_.size (); ++i) {
 	const Data& d = data_[i];
-	if ((d.constraint == constraint) || (*d.constraint == *constraint)) {
+	if ((d.constraint == constraint) || (*d.constraint == *constraint)
+    || d.constraint->function() == constraint->function()) {
 	  rhs = d.rhs_implicit.vector();
 	  return true;
 	}

--- a/src/explicit.cc
+++ b/src/explicit.cc
@@ -124,6 +124,23 @@ namespace hpp {
           <pinocchio::DerivativeTimesInput> (f_value, rhs.vector(), jacobian);
       }
     }
+    
+    bool Explicit::isEqual (const Implicit& other, bool swapAndTest) const
+    {
+      if (swapAndTest && !Implicit::isEqual(other, swapAndTest)) return false;
+      try {
+        const Explicit& castother = dynamic_cast<const Explicit&>(other);
+        if (inputToOutput_ != castother.inputToOutput_) return false;
+        if (inputConf_ != castother.inputConf_) return false;
+        if (outputConf_ != castother.outputConf_) return false;
+        if (inputVelocity_ != castother.inputVelocity_) return false;
+        if (outputVelocity_ != castother.outputVelocity_) return false;
+        if (swapAndTest) return castother.isEqual (*this, false);
+        return true;
+      } catch (const std::bad_cast& err) {
+        return false;
+      }
+    }
 
     ImplicitPtr_t Explicit::copy () const
     {

--- a/src/explicit/convex-shape-contact.cc
+++ b/src/explicit/convex-shape-contact.cc
@@ -167,7 +167,8 @@ namespace hpp {
             pose_.push_back(RelativePose::create
                             ("",robot, fs[j].joint_, os[i].joint_,
                              posInJoint, os[i].positionInJoint(),
-                             6 * Equality, std::vector<bool>(6, true)));
+                             EqualToZero << 3 * Equality << 2 * EqualToZero,
+                             std::vector<bool>(6, true)));
           }
         }
       }

--- a/src/implicit.cc
+++ b/src/implicit.cc
@@ -193,7 +193,7 @@ namespace hpp {
     {
       if (comparison_ != other.comparison_) return false;
       if (rhs_.size() != other.rhs_.size()) return false;
-      if (function_ != other.function_) return false;
+      if (function_ != other.function_ && *function_ != *other.function_) return false;
       if (swapAndTest) return other.isEqual (*this, false);
       return true;
     }

--- a/src/solver/by-substitution.cc
+++ b/src/solver/by-substitution.cc
@@ -223,7 +223,7 @@ namespace hpp {
       }
 
       void BySubstitution::projectVectorOnKernel
-      (ConfigurationIn_t arg, vectorIn_t darg, ConfigurationOut_t result) const
+      (ConfigurationIn_t arg, vectorIn_t darg, vectorOut_t result) const
       {
         if (constraints_.empty () || reducedDimension() == 0) {
           result = darg;
@@ -242,6 +242,8 @@ namespace hpp {
         vector_t tmp (getV1(svd_, rank).adjoint() * dqSmall_);
         dqSmall_.noalias() -= getV1(svd_, rank) * tmp;
 
+        // Otherwise two uninitialized values may sum up to NaN
+        result.setZero();
         freeVariables_.lview(result) = dqSmall_;
       }
 


### PR DESCRIPTION
We sometimes need to compare DifferentiableFunctions in order to build lists without duplicates or easily detect incompatible constraints. So far we were using pointer equality or name equality. Now the fields are compared.
- Equality operator implemented in DifferentiableFunction and all child classes
- Equality tests like dfPtr1 == dfPtr2 replaced with *dfPtr1 == *dfPtr2 where relevant