### PR TITLE
[DifferentiableFunction] Fix operator==

### DIFF
--- a/include/hpp/constraints/convex-shape.hh
+++ b/include/hpp/constraints/convex-shape.hh
@@ -166,6 +166,7 @@ namespace hpp {
           if (Ls_ != other.Ls_) return false;
           if (MinJoint_ != other.MinJoint_) return false;
           if (joint_ != other.joint_) return false;
+	  return true;
         }
         bool operator!=(ConvexShape const & other) const {
           return !(this->operator==(other));

--- a/include/hpp/constraints/qp-static-stability.hh
+++ b/include/hpp/constraints/qp-static-stability.hh
@@ -78,7 +78,7 @@ namespace hpp {
           if (!DifferentiableFunction::isEqual(other))
             return false;
           
-          if (name_ != castother.name_)
+          if (name() != castother.name())
             return false;
           if (robot_ != castother.robot_)
             return false;


### PR DESCRIPTION
  - ConvexShape::operator== return true if objects are equal,
  - QPStaticStability::isEqual does not use private member of parent class
    anymore.