### PR TITLE
Add method to retrieve joints involved in a constraint function

### DIFF
--- a/include/hpp/constraints/differentiable-function.hh
+++ b/include/hpp/constraints/differentiable-function.hh
@@ -188,7 +188,23 @@ namespace hpp {
 
       bool operator== (DifferentiableFunction const & other) const;
       bool operator!= (DifferentiableFunction const & b) const;
-      //virtual bool isEqual(DifferentiableFunctionPtr_t const &, bool) const {return true;}
+
+      /// Return pair of joints the relative pose between which
+      /// modifies the function value if any
+      ///
+      /// This method is useful to know whether an instance of Implicit constrains
+      /// the relative pose between two joints.
+      /// \param robot the robot the constraints are applied on,
+      /// \return the pair of joints involved, arranged in order of increasing
+      /// joint index, or a pair of empty shared pointers.
+      /// \note if absolute pose (relative pose with respect to "universe"),
+      /// "universe" is returned as empty shared pointer
+      virtual std::pair<JointConstPtr_t, JointConstPtr_t> dependsOnRelPoseBetween
+          (DeviceConstPtr_t robot) const
+      {
+        return std::pair<JointConstPtr_t, JointConstPtr_t>(nullptr, nullptr);
+      };
+
     protected:
       /// \brief Concrete class constructor should call this constructor.
       ///

--- a/include/hpp/constraints/explicit/implicit-function.hh
+++ b/include/hpp/constraints/explicit/implicit-function.hh
@@ -42,7 +42,7 @@ namespace hpp {
     ///      q,
     ///  \li q_in is the vector composed of other configuration variables of
     ///      q,
-    ///  f, g are differentiable functions with values in  a Lie group.
+    ///  \li f, g are differentiable functions with values in a Lie group.
     ///
     ///  This class is mainly used to create hpp::constraints::Explicit
     ///  instances.
@@ -111,6 +111,22 @@ namespace hpp {
 
         return true;
       }
+
+      /// Return pair of joints the relative pose between which
+      /// modifies the function value if any
+      ///
+      /// Currently checks if the implicit function specifies a joint
+      /// where
+      ///  \li q_out is a vector corresponding to only 1 joint
+      ///  \li q_in is an empty vector (since f is constant and specifies
+      ///      the whole or part of the pose of the joint)
+      /// \param robot the robot the constraints are applied on,
+      /// \return pair of pointers to the lock joint and its parent joint,
+      /// arranged in order of increasing joint index, or a pair of empty
+      /// shared pointers if the implicit function does not specify a locked
+      /// joint.
+      std::pair<JointConstPtr_t, JointConstPtr_t> dependsOnRelPoseBetween
+          (DeviceConstPtr_t robot) const;
 
     private:
       void computeJacobianBlocks ();

--- a/include/hpp/constraints/explicit/relative-transformation.hh
+++ b/include/hpp/constraints/explicit/relative-transformation.hh
@@ -45,9 +45,9 @@ namespace hpp {
     /// Relative transformation as a mapping between configuration variables
     ///
     /// When the positions of two joints are constrained by a full
-    /// transformation constraint, if the second joint is hold by a freeflyer
+    /// transformation constraint, if the second joint is held by a freeflyer
     /// joint, the position of this latter joint can be
-    /// explicitely expressed with respect to the position of the first joint.
+    /// explicitly expressed with respect to the position of the first joint.
     ///
     /// This class provides this expression. The input configuration variables
     /// are the joint values of all joints except the above mentioned freeflyer
@@ -83,6 +83,29 @@ namespace hpp {
       {
         return joint2_;
       }
+
+      /// Return pair of joints the relative pose between which
+      /// modifies the function value if any
+      ///
+      /// This method is useful to know whether an instance of Implicit constrains
+      /// the relative pose between two joints.
+      /// \param robot the robot the constraints are applied on,
+      /// \return the pair of joints involved, arranged in order of increasing
+      /// joint index, or a pair of empty shared pointers.
+      /// \note if absolute pose (relative pose with respect to "universe"),
+      /// "universe" is returned as empty shared pointer
+      std::pair<JointConstPtr_t, JointConstPtr_t> dependsOnRelPoseBetween
+          (DeviceConstPtr_t robot) const {
+        JointConstPtr_t j1 = joint1();
+        JointConstPtr_t j2 = joint2();
+        size_type index1 = (j1? j1->index(): 0);
+        size_type index2 = (j2? j2->index(): 0);
+        if (index1 <= index2) {
+          return std::pair<JointConstPtr_t, JointConstPtr_t>(j1, j2);
+        } else {
+          return std::pair<JointConstPtr_t, JointConstPtr_t>(j2, j1);
+        }
+      };
 
     protected:
       typedef Eigen::BlockIndex BlockIndex;

--- a/include/hpp/constraints/fwd.hh
+++ b/include/hpp/constraints/fwd.hh
@@ -48,6 +48,7 @@ namespace hpp {
     typedef pinocchio::value_type value_type;
     typedef pinocchio::JointPtr_t JointPtr_t;
     typedef pinocchio::JointConstPtr_t JointConstPtr_t;
+    typedef pinocchio::Joint Joint;
     typedef pinocchio::vector3_t vector3_t;
     typedef pinocchio::matrix3_t matrix3_t;
     typedef Eigen::Matrix<value_type, 6, 6> matrix6_t;
@@ -106,6 +107,7 @@ namespace hpp {
     typedef pinocchio::ConfigurationOut_t ConfigurationOut_t;
     typedef pinocchio::Device Device;
     typedef pinocchio::DevicePtr_t DevicePtr_t;
+    typedef pinocchio::DeviceConstPtr_t DeviceConstPtr_t;
     typedef pinocchio::CenterOfMassComputation CenterOfMassComputation;
     typedef pinocchio::CenterOfMassComputationPtr_t CenterOfMassComputationPtr_t;
     typedef shared_ptr <DifferentiableFunction>

--- a/include/hpp/constraints/generic-transformation.hh
+++ b/include/hpp/constraints/generic-transformation.hh
@@ -300,6 +300,30 @@ namespace hpp {
 	return m_.F2inJ2;
       }
 
+      /// Return pair of joints the relative pose between which
+      /// modifies the function value if any
+      ///
+      /// This method is useful to know whether an instance of Implicit constrains
+      /// the relative pose between two joints.
+      /// \param robot the robot the constraints are applied on,
+      /// \return the pair of joints involved, arranged in order of increasing
+      /// joint index, or a pair of empty shared pointers. or a pair of empty shared pointers.
+      /// \note if absolute pose (relative pose with respect to "universe"),
+      /// "universe" is returned as empty shared pointer
+      std::pair<JointConstPtr_t, JointConstPtr_t> dependsOnRelPoseBetween
+          (DeviceConstPtr_t robot) const
+      {
+        JointConstPtr_t j1 = joint1();
+        JointConstPtr_t j2 = joint2();
+        size_type index1 = Joint::index(j1);
+        size_type index2 = Joint::index(j2);
+        if (index1 <= index2) {
+          return std::pair<JointConstPtr_t, JointConstPtr_t>(j1, j2);
+        } else {
+          return std::pair<JointConstPtr_t, JointConstPtr_t>(j2, j1);
+        }
+      };
+
       virtual std::ostream& print (std::ostream& o) const;
 
       ///Constructor

--- a/include/hpp/constraints/implicit.hh
+++ b/include/hpp/constraints/implicit.hh
@@ -242,9 +242,17 @@ namespace hpp {
         /// Set the comparison type
         void comparisonType (const ComparisonTypes_t& comp);
 
+        /// Return the active rows taken into account
+        /// to determine whether the constraint is satisfied
         const segments_t& activeRows() const
         {
           return activeRows_;
+        }
+
+        /// Check if all rows are active (no inactive rows)
+        bool checkAllRowsActive() const
+        {
+          return inactiveRows_.nbRows() == 0;
         }
 
         /// Get indices of constraint coordinates that are equality
@@ -269,6 +277,21 @@ namespace hpp {
         {
           return function_;
         }
+
+        /// Get pair of joints whose relative pose is fully constrained
+        ///
+        /// If the function value depends on the relative pose between j1 and j2
+        /// and if the relative pose between j1 and j2 is fully constrained
+        /// because of Implicit constraint (relative transformation may still
+        /// differ from one path to another), return these two joints.
+        /// \param robot the device that this constraint is applied to
+        /// \return the pair of joints constrained, in order of increasing
+        /// joint index, or a pair of empty shared pointers
+        /// \note absolute pose is considered relative pose with respect to
+        /// "universe". "universe" is returned as a nullpointer
+        /// as the first element of the pair, if applicable.
+        virtual std::pair<JointConstPtr_t, JointConstPtr_t> doesConstrainRelPoseBetween
+          (DeviceConstPtr_t robot) const;
 
       protected:
         /// Constructor

--- a/include/hpp/constraints/locked-joint.hh
+++ b/include/hpp/constraints/locked-joint.hh
@@ -139,6 +139,18 @@ namespace hpp {
       }
       /// Print object in a stream
       std::ostream& print (std::ostream& os) const;
+
+      /// Get pair of joints whose relative pose is fully constrained
+      ///
+      /// \param robot the device that this constraint is applied to
+      /// \return pair of pointers to the parent joint and the locked joint,
+      /// arranged in order of increasing joint index
+      /// \note absolute pose is considered relative pose with respect to
+      /// "universe". "universe" is returned as a nullpointer
+      /// as the first element of the pair, if applicable.
+      virtual std::pair<JointConstPtr_t, JointConstPtr_t> doesConstrainRelPoseBetween
+        (DeviceConstPtr_t robot) const;
+
     protected:
       /// Constructor
       /// \param joint joint that is locked,

--- a/src/implicit.cc
+++ b/src/implicit.cc
@@ -285,6 +285,21 @@ namespace hpp {
       }
     }
 
+    std::pair<JointConstPtr_t, JointConstPtr_t> Implicit::doesConstrainRelPoseBetween
+        (DeviceConstPtr_t robot) const
+    {
+      std::pair<JointConstPtr_t, JointConstPtr_t> joints =
+          function_->dependsOnRelPoseBetween(robot);
+      // check that the constraint fully constrains the relative pose
+      if (function_->outputSpace()->nv() != 6 ||
+          !checkAllRowsActive()) {
+        hppDout (info, "Constraint " << function_->name ()
+                << " does not fully constrain the relative pose of joints");
+        return std::pair<JointConstPtr_t, JointConstPtr_t>(nullptr, nullptr);
+      }
+      return joints;
+    }
+
     template<class Archive>
     void Implicit::serialize(Archive & ar, const unsigned int version)
     {

--- a/tests/convex-shape-contact.cc
+++ b/tests/convex-shape-contact.cc
@@ -152,6 +152,19 @@ BOOST_AUTO_TEST_CASE(convexShapeContact)
                                  contactConstraint->functionPtr()));
   value_type M(f->contactConstraint()->radius());
   BOOST_CHECK(M > sqrt(2));
+  // check that the two joints involved can be retrieved correctly
+  std::pair<JointConstPtr_t, JointConstPtr_t> joints =
+    f->dependsOnRelPoseBetween(robot);
+  BOOST_CHECK_EQUAL (Joint::index(joints.first), Joint::index(j1));
+  BOOST_CHECK_EQUAL (Joint::index(joints.second), Joint::index(j2));
+
+  joints = f->contactConstraint()->dependsOnRelPoseBetween(robot);
+  BOOST_CHECK_EQUAL (Joint::index(joints.first), Joint::index(j1));
+  BOOST_CHECK_EQUAL (Joint::index(joints.second), Joint::index(j2));
+
+  joints = f->complement()->dependsOnRelPoseBetween(robot);
+  BOOST_CHECK_EQUAL (Joint::index(joints.first), Joint::index(j1));
+  BOOST_CHECK_EQUAL (Joint::index(joints.second), Joint::index(j2));
   // box 1 above box 2: surfaces in contact are
   //  - floor surface 1 for box 1,
   //  - object surface 0 for box 2.


### PR DESCRIPTION
Some function values are dependent on the pose of a pair of joints, such that the value of the function remains constant if the joints relative motion is constrained in a transition. 

One case where this is useful is when propagating constraints backwards: if we know that i) a goal configuration must satisfy constraint `c1`, and ii) `c1` function involves joints `j1` and `j2`, and iii) `j1` and `j2` are constrained in the transition leading to the goal configuration, we can conclude that the configuration right before the transition (and even along the transition) must satisfy the constraint.