### PR TITLE
Minor fix for assert normalized quaternion

### DIFF
--- a/include/hpp/constraints/differentiable-function-set.hh
+++ b/include/hpp/constraints/differentiable-function-set.hh
@@ -112,8 +112,8 @@ class HPP_CONSTRAINTS_DLLAPI DifferentiableFunctionSet
       result.vector().segment(row, f.outputSize()) = result_[i].vector();
       row += f.outputSize();
       ++i;
-      assert(hpp::pinocchio::checkNormalized(result));
     }
+    assert(hpp::pinocchio::checkNormalized(result));
   }
   void impl_jacobian(matrixOut_t jacobian, ConfigurationIn_t arg) const {
     size_type row = 0;


### PR DESCRIPTION
The assert raises issue even when the calculation is performed properly,
because the assert checks even before `result` is fully
computed. This has been fixed by simply moving the assert line.