### PR TITLE
Update fwd.hh to match new logic of cmake JRL submodule of deprecated with typedef

### DIFF
--- a/include/hpp/constraints/fwd.hh
+++ b/include/hpp/constraints/fwd.hh
@@ -112,8 +112,7 @@ typedef pinocchio::CenterOfMassComputation CenterOfMassComputation;
 typedef pinocchio::CenterOfMassComputationPtr_t CenterOfMassComputationPtr_t;
 typedef shared_ptr<DifferentiableFunction> DifferentiableFunctionPtr_t;
 typedef shared_ptr<DifferentiableFunctionSet> DifferentiableFunctionSetPtr_t;
-typedef DifferentiableFunctionSet DifferentiableFunctionStack
-    HPP_CONSTRAINTS_DEPRECATED;
+HPP_CONSTRAINTS_DEPRECATED typedef DifferentiableFunctionSet DifferentiableFunctionStack;
 typedef shared_ptr<ActiveSetDifferentiableFunction>
     ActiveSetDifferentiableFunctionPtr_t;
 typedef shared_ptr<DistanceBetweenBodies> DistanceBetweenBodiesPtr_t;


### PR DESCRIPTION
It follows the issue raised in JRL cmake submodules : https://github.com/jrl-umi3218/jrl-cmakemodules/issues/563#issuecomment-1308090359