### PR TITLE
Fix wrong asserts and tests.

### DIFF
--- a/src/generic-transformation/helper.hh
+++ b/src/generic-transformation/helper.hh
@@ -347,15 +347,36 @@ struct relativeTransform {
     // There is no joint1
     const Transform3f& M2 = d.M2();
     d.value.noalias() = M2.act(d.model.F2inJ2.translation());
-    assert(hpp::pinocchio::checkNormalized(
-        LiegroupElement(d.value, LiegroupSpace::R3xSO3())));
+#ifndef NDEBUG
+    if (ose3){
+      hpp::pinocchio::vector4_t quat;
+      size_type n=d.value.size();
+      assert(n>=4);
+      quat << d.value[n-4], d.value[n-3], d.value[n-2], d.value[n-1];
+      assert(hpp::pinocchio::checkNormalized(LiegroupElement(quat, LiegroupSpace::SO3())));
+    }
+#endif
     if (!d.model.t1isZero) d.value.noalias() -= d.model.F1inJ1.translation();
-    assert(hpp::pinocchio::checkNormalized(
-        LiegroupElement(d.value, LiegroupSpace::R3xSO3())));
+#ifndef NDEBUG
+    if (ose3){
+      hpp::pinocchio::vector4_t quat;
+      size_type n=d.value.size();
+      assert(n>=4);
+      quat << d.value[n-4], d.value[n-3], d.value[n-2], d.value[n-1];
+      assert(hpp::pinocchio::checkNormalized(LiegroupElement(quat, LiegroupSpace::SO3())));
+    }
+#endif
     if (!d.model.R1isID)
       d.value.applyOnTheLeft(d.model.F1inJ1.rotation().transpose());
-    assert(hpp::pinocchio::checkNormalized(
-        LiegroupElement(d.value, LiegroupSpace::R3xSO3())));
+#ifndef NDEBUG
+    if (ose3){
+      hpp::pinocchio::vector4_t quat;
+      size_type n=d.value.size();
+      assert(n>=4);
+      quat << d.value[n-4], d.value[n-3], d.value[n-2], d.value[n-1];
+      assert(hpp::pinocchio::checkNormalized(LiegroupElement(quat, LiegroupSpace::SO3())));
+    }
+#endif
   }
 };
 template <>
@@ -409,9 +430,15 @@ struct compute {
     using hpp::pinocchio::LiegroupSpace;
     relativeTransform<rel, ori>::run(d);
     unary<ori>::log(d);
-    if (ose3)
-      assert(hpp::pinocchio::checkNormalized(
-          LiegroupElement(d.value, LiegroupSpace::R3xSO3())));
+#ifndef NDEBUG
+    if (ose3){
+      hpp::pinocchio::vector4_t quat;
+      size_type n=d.value.size();
+      assert(n>=4);
+      quat << d.value[n-4], d.value[n-3], d.value[n-2], d.value[n-1];
+      assert(hpp::pinocchio::checkNormalized(LiegroupElement(quat, LiegroupSpace::SO3())));
+    }
+#endif
   }
 
   static inline void jacobian(GTDataJ<rel, pos, ori, ose3>& d,

--- a/src/generic-transformation/helper.hh
+++ b/src/generic-transformation/helper.hh
@@ -348,33 +348,36 @@ struct relativeTransform {
     const Transform3f& M2 = d.M2();
     d.value.noalias() = M2.act(d.model.F2inJ2.translation());
 #ifndef NDEBUG
-    if (ose3){
+    if (ose3) {
       hpp::pinocchio::vector4_t quat;
-      size_type n=d.value.size();
-      assert(n>=4);
-      quat << d.value[n-4], d.value[n-3], d.value[n-2], d.value[n-1];
-      assert(hpp::pinocchio::checkNormalized(LiegroupElement(quat, LiegroupSpace::SO3())));
+      size_type n = d.value.size();
+      assert(n >= 4);
+      quat << d.value[n - 4], d.value[n - 3], d.value[n - 2], d.value[n - 1];
+      assert(hpp::pinocchio::checkNormalized(
+          LiegroupElement(quat, LiegroupSpace::SO3())));
     }
 #endif
     if (!d.model.t1isZero) d.value.noalias() -= d.model.F1inJ1.translation();
 #ifndef NDEBUG
-    if (ose3){
+    if (ose3) {
       hpp::pinocchio::vector4_t quat;
-      size_type n=d.value.size();
-      assert(n>=4);
-      quat << d.value[n-4], d.value[n-3], d.value[n-2], d.value[n-1];
-      assert(hpp::pinocchio::checkNormalized(LiegroupElement(quat, LiegroupSpace::SO3())));
+      size_type n = d.value.size();
+      assert(n >= 4);
+      quat << d.value[n - 4], d.value[n - 3], d.value[n - 2], d.value[n - 1];
+      assert(hpp::pinocchio::checkNormalized(
+          LiegroupElement(quat, LiegroupSpace::SO3())));
     }
 #endif
     if (!d.model.R1isID)
       d.value.applyOnTheLeft(d.model.F1inJ1.rotation().transpose());
 #ifndef NDEBUG
-    if (ose3){
+    if (ose3) {
       hpp::pinocchio::vector4_t quat;
-      size_type n=d.value.size();
-      assert(n>=4);
-      quat << d.value[n-4], d.value[n-3], d.value[n-2], d.value[n-1];
-      assert(hpp::pinocchio::checkNormalized(LiegroupElement(quat, LiegroupSpace::SO3())));
+      size_type n = d.value.size();
+      assert(n >= 4);
+      quat << d.value[n - 4], d.value[n - 3], d.value[n - 2], d.value[n - 1];
+      assert(hpp::pinocchio::checkNormalized(
+          LiegroupElement(quat, LiegroupSpace::SO3())));
     }
 #endif
   }
@@ -431,12 +434,13 @@ struct compute {
     relativeTransform<rel, ori>::run(d);
     unary<ori>::log(d);
 #ifndef NDEBUG
-    if (ose3){
+    if (ose3) {
       hpp::pinocchio::vector4_t quat;
-      size_type n=d.value.size();
-      assert(n>=4);
-      quat << d.value[n-4], d.value[n-3], d.value[n-2], d.value[n-1];
-      assert(hpp::pinocchio::checkNormalized(LiegroupElement(quat, LiegroupSpace::SO3())));
+      size_type n = d.value.size();
+      assert(n >= 4);
+      quat << d.value[n - 4], d.value[n - 3], d.value[n - 2], d.value[n - 1];
+      assert(hpp::pinocchio::checkNormalized(
+          LiegroupElement(quat, LiegroupSpace::SO3())));
     }
 #endif
   }

--- a/tests/solver-by-substitution.cc
+++ b/tests/solver-by-substitution.cc
@@ -1002,8 +1002,7 @@ BOOST_AUTO_TEST_CASE(rightHandSideFromConfig) {
   //           rhs [11]
   //           rhs [12]
   for (size_type i = 0; i < 1000; ++i) {
-    Configuration_t q(device->configSize());
-    q.setRandom();
+    Configuration_t q = ::pinocchio::randomConfiguration(device->model());
     bool success;
     // Set right hand side for both constraints from random configuration
     success = solver.rightHandSideFromConfig(c1, q);
@@ -1024,7 +1023,7 @@ BOOST_AUTO_TEST_CASE(rightHandSideFromConfig) {
     success = solver.getRightHandSide(c2, rhs2);
     BOOST_CHECK(success);
     // Set right hand side for both constraints from other random configuration
-    q.setRandom();
+    q = ::pinocchio::randomConfiguration(device->model());
     success = solver.rightHandSideFromConfig(c1, q);
     BOOST_CHECK(success);
     success = solver.rightHandSideFromConfig(c2, q);


### PR DESCRIPTION
  Normalization check was wrong for GenericTransformation that provided as
  output a member of SO3.
  In tests/solver-by-substitution.cc, random configurations where generated
  using setRandom method that does not take into account quaternion
  normalization.

This should fix https://github.com/humanoid-path-planner/hpp-constraints/issues/174.