### PR TITLE
[HierarchicalIterative] Fix staturation::Bounds computation.

### DIFF
--- a/include/hpp/constraints/solver/hierarchical-iterative.hh
+++ b/include/hpp/constraints/solver/hierarchical-iterative.hh
@@ -132,16 +132,14 @@ struct Function : Base {
 struct Bounds : Base {
   bool saturate(vectorIn_t q, vectorOut_t qSat, Eigen::VectorXi& saturation);
   Bounds() {}
-  Bounds(const vector_t& lb, const vector_t& ub) :
-    lb(lb), ub(ub), iq2iv_()
-  {
+  Bounds(const vector_t& lb, const vector_t& ub) : lb(lb), ub(ub), iq2iv_() {
     iq2iv_.resize(ub.size());
-    for (size_type i=0; i<ub.size(); ++i){
+    for (size_type i = 0; i < ub.size(); ++i) {
       iq2iv_[i] = i;
     }
   }
-  Bounds(const vector_t& lb, const vector_t& ub, const Eigen::VectorXi& iq2iv) :
-    lb(lb), ub(ub), iq2iv_(iq2iv) {}
+  Bounds(const vector_t& lb, const vector_t& ub, const Eigen::VectorXi& iq2iv)
+      : lb(lb), ub(ub), iq2iv_(iq2iv) {}
   vector_t lb, ub;
   Eigen::VectorXi iq2iv_;
 };

--- a/include/hpp/constraints/solver/hierarchical-iterative.hh
+++ b/include/hpp/constraints/solver/hierarchical-iterative.hh
@@ -132,8 +132,18 @@ struct Function : Base {
 struct Bounds : Base {
   bool saturate(vectorIn_t q, vectorOut_t qSat, Eigen::VectorXi& saturation);
   Bounds() {}
-  Bounds(const vector_t& lb, const vector_t& ub) : lb(lb), ub(ub) {}
+  Bounds(const vector_t& lb, const vector_t& ub) :
+    lb(lb), ub(ub), iq2iv_()
+  {
+    iq2iv_.resize(ub.size());
+    for (size_type i=0; i<ub.size(); ++i){
+      iq2iv_[i] = i;
+    }
+  }
+  Bounds(const vector_t& lb, const vector_t& ub, const Eigen::VectorXi& iq2iv) :
+    lb(lb), ub(ub), iq2iv_(iq2iv) {}
   vector_t lb, ub;
+  Eigen::VectorXi iq2iv_;
 };
 /// \brief Box constraints use a Device joint limits.
 struct Device : Base {

--- a/src/solver/hierarchical-iterative.cc
+++ b/src/solver/hierarchical-iterative.cc
@@ -140,7 +140,7 @@ bool Bounds::saturate(vectorIn_t q, vectorOut_t qSat,
                       Eigen::VectorXi& saturation) {
   bool sat = false;
   for (size_type i = 0; i < q.size(); ++i)
-    if (clamp(lb[i], ub[i], q[i], qSat[i], saturation[i])) sat = true;
+    if (clamp(lb[i], ub[i], q[i], qSat[i], saturation[iq2iv_[i]])) sat = true;
   return sat;
 }
 


### PR DESCRIPTION
  saturation vector is of same size as velocity. Therefore, we need to use
  a mapping from configuration indices to velocity indices.
  A constructor taking such an object has been added. For backward
  compatibility, the default constructor builds a trivial mapping.