### PR TITLE
[Manipulability] Make definition better fit name of function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ set(${PROJECT_NAME}_HEADERS
     include/hpp/constraints/generic-transformation.hh
     include/hpp/constraints/macros.hh
     include/hpp/constraints/manipulability.hh
+    include/hpp/constraints/min-manipulability.hh
     include/hpp/constraints/convex-shape.hh
     include/hpp/constraints/convex-shape-contact.hh
     include/hpp/constraints/static-stability.hh
@@ -148,6 +149,7 @@ set(${PROJECT_NAME}_SOURCES
     src/extracted-function.hh
     src/matrix-view.cc
     src/manipulability.cc
+    src/min-manipulability.cc
     src/static-stability.cc
     src/explicit-constraint-set.cc
     src/implicit.cc

--- a/include/hpp/constraints/min-manipulability.hh
+++ b/include/hpp/constraints/min-manipulability.hh
@@ -1,0 +1,112 @@
+// Copyright (c) 2018 - 2026 CNRS
+// Authors: Joseph Mirabel, Florent Lamiraux
+//
+
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+
+#ifndef HPP_CONSTRAINTS_MIN_MANIPULABILITY_HH
+#define HPP_CONSTRAINTS_MIN_MANIPULABILITY_HH
+
+#include <hpp/constraints/config.hh>
+#include <hpp/constraints/differentiable-function.hh>
+#include <hpp/constraints/fwd.hh>
+#include <hpp/constraints/matrix-view.hh>
+
+namespace hpp {
+namespace constraints {
+HPP_PREDEF_CLASS(MinManipulability);
+typedef shared_ptr<MinManipulability> MinManipulabilityPtr_t;
+
+/// \addtogroup constraints
+/// \{
+
+/// Enforce minimal manipulability
+///
+/// This function takes as input another differentiable function \f$f_1\f$ defined over
+/// the same configuration space and computes a one dimensional value as follows:
+///
+/// \f[
+/// f(\mathbf{q}) = \max \left(-\log\det(J_1 J_1^T), 0\right)
+/// \f]
+/// where \f$J_1\f$ is the Jacobian matrix of \f$f_1\f$.
+///
+/// As a consequence when,
+///   \li \f$\det(J_1 J_1^T) \geq 1\f$, the function is uniformly equal to 0,
+///   \li \f$\det(J_1 J_1^T) < 1\f$, the function is positive.
+///
+/// Inserting a \link hpp::constraints::Implicit constraint  \endlink with this function
+/// with comparison type EQUAL_TO_ZERO into a numerical solver will make the solution
+/// lie in the domain defined by \f$\det(J_1 J_1^T) \geq 1\f$, where the Jacobian of
+/// \f$f_1\f$ has a manipulability index (product of singular values) greater than 1.
+///
+/// \note The Jacobian of this function is computed by finite difference.
+class HPP_CONSTRAINTS_DLLAPI MinManipulability : public DifferentiableFunction {
+ public:
+  virtual ~MinManipulability() {}
+
+  static MinManipulabilityPtr_t create(DifferentiableFunctionPtr_t function,
+                                    DevicePtr_t robot, std::string name) {
+    return MinManipulabilityPtr_t(new MinManipulability(function, robot, name));
+  }
+
+ protected:
+  /// \brief Concrete class constructor should call this constructor.
+  ///
+  /// \param function the function which must be analysed
+  /// \param name function's name
+  MinManipulability(DifferentiableFunctionPtr_t function, DevicePtr_t robot,
+                 std::string name);
+
+  void impl_compute(LiegroupElementRef result, vectorIn_t argument) const;
+
+  void impl_jacobian(matrixOut_t jacobian, vectorIn_t arg) const;
+
+  bool isEqual(const DifferentiableFunction& other) const {
+    const MinManipulability& castother =
+        dynamic_cast<const MinManipulability&>(other);
+    if (!DifferentiableFunction::isEqual(other)) return false;
+
+    if (function_ != castother.function_) return false;
+    if (robot_ != castother.robot_) return false;
+    if (cols_.cols() != castother.cols_.cols()) return false;
+    if (J_ != castother.J_) return false;
+    if (J_JT_ != castother.J_JT_) return false;
+
+    return true;
+  }
+
+ private:
+  DifferentiableFunctionPtr_t function_;
+  DevicePtr_t robot_;
+
+  Eigen::ColBlockIndices cols_;
+
+  mutable matrix_t J_, J_JT_;
+};  // class MinManipulability
+/// \}
+}  // namespace constraints
+}  // namespace hpp
+
+#endif  // HPP_CONSTRAINTS_MIN_MANIPULABILITY_HH

--- a/include/hpp/constraints/min-manipulability.hh
+++ b/include/hpp/constraints/min-manipulability.hh
@@ -44,8 +44,9 @@ typedef shared_ptr<MinManipulability> MinManipulabilityPtr_t;
 
 /// Enforce minimal manipulability
 ///
-/// This function takes as input another differentiable function \f$f_1\f$ defined over
-/// the same configuration space and computes a one dimensional value as follows:
+/// This function takes as input another differentiable function \f$f_1\f$
+/// defined over the same configuration space and computes a one dimensional
+/// value as follows:
 ///
 /// \f[
 /// f(\mathbf{q}) = \max \left(-\log\det(J_1 J_1^T), 0\right)
@@ -56,10 +57,12 @@ typedef shared_ptr<MinManipulability> MinManipulabilityPtr_t;
 ///   \li \f$\det(J_1 J_1^T) \geq 1\f$, the function is uniformly equal to 0,
 ///   \li \f$\det(J_1 J_1^T) < 1\f$, the function is positive.
 ///
-/// Inserting a \link hpp::constraints::Implicit constraint  \endlink with this function
-/// with comparison type EQUAL_TO_ZERO into a numerical solver will make the solution
-/// lie in the domain defined by \f$\det(J_1 J_1^T) \geq 1\f$, where the Jacobian of
-/// \f$f_1\f$ has a manipulability index (product of singular values) greater than 1.
+/// Inserting a \link hpp::constraints::Implicit constraint  \endlink with this
+/// function with comparison type EQUAL_TO_ZERO into a numerical solver will
+/// make the solution lie in the domain defined by \f$\det(J_1 J_1^T) \geq 1\f$,
+/// where the Jacobian of
+/// \f$f_1\f$ has a manipulability index (product of singular values) greater
+/// than 1.
 ///
 /// \note The Jacobian of this function is computed by finite difference.
 class HPP_CONSTRAINTS_DLLAPI MinManipulability : public DifferentiableFunction {
@@ -67,7 +70,7 @@ class HPP_CONSTRAINTS_DLLAPI MinManipulability : public DifferentiableFunction {
   virtual ~MinManipulability() {}
 
   static MinManipulabilityPtr_t create(DifferentiableFunctionPtr_t function,
-                                    DevicePtr_t robot, std::string name) {
+                                       DevicePtr_t robot, std::string name) {
     return MinManipulabilityPtr_t(new MinManipulability(function, robot, name));
   }
 
@@ -77,7 +80,7 @@ class HPP_CONSTRAINTS_DLLAPI MinManipulability : public DifferentiableFunction {
   /// \param function the function which must be analysed
   /// \param name function's name
   MinManipulability(DifferentiableFunctionPtr_t function, DevicePtr_t robot,
-                 std::string name);
+                    std::string name);
 
   void impl_compute(LiegroupElementRef result, vectorIn_t argument) const;
 

--- a/src/min-manipulability.cc
+++ b/src/min-manipulability.cc
@@ -100,7 +100,8 @@ void MinManipulability::impl_compute(LiegroupElementRef res,
   res.vector()[0] = std::max(-logAbsDeterminant, 0.);
 }
 
-void MinManipulability::impl_jacobian(matrixOut_t jacobian, vectorIn_t arg) const {
+void MinManipulability::impl_jacobian(matrixOut_t jacobian,
+                                      vectorIn_t arg) const {
   finiteDifferenceCentral(jacobian, arg, robot_, 1e-8);
 }
 }  // namespace constraints

--- a/src/min-manipulability.cc
+++ b/src/min-manipulability.cc
@@ -26,12 +26,12 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 // DAMAGE.
 
-#include <hpp/constraints/manipulability.hh>
+#include <hpp/constraints/min-manipulability.hh>
 
 namespace hpp {
 namespace constraints {
-Manipulability::Manipulability(DifferentiableFunctionPtr_t function,
-                               DevicePtr_t robot, std::string name)
+MinManipulability::MinManipulability(DifferentiableFunctionPtr_t function,
+                                     DevicePtr_t robot, std::string name)
     : DifferentiableFunction(function->inputSize(),
                              function->inputDerivativeSize(), 1, name),
       function_(function),
@@ -43,8 +43,8 @@ Manipulability::Manipulability(DifferentiableFunctionPtr_t function,
   J_JT_.resize(J_.rows(), J_.rows());
 }
 
-void Manipulability::impl_compute(LiegroupElementRef res,
-                                  vectorIn_t arg) const {
+void MinManipulability::impl_compute(LiegroupElementRef res,
+                                     vectorIn_t arg) const {
   assert(cols_.cols().size() > 0);
 
   function_->jacobian(J_, arg);
@@ -97,10 +97,10 @@ void Manipulability::impl_compute(LiegroupElementRef res,
 
   // This funcion will be used as a cost function whose squared norm is to
   // be minimized.
-  res.vector()[0] = logAbsDeterminant;
+  res.vector()[0] = std::max(-logAbsDeterminant, 0.);
 }
 
-void Manipulability::impl_jacobian(matrixOut_t jacobian, vectorIn_t arg) const {
+void MinManipulability::impl_jacobian(matrixOut_t jacobian, vectorIn_t arg) const {
   finiteDifferenceCentral(jacobian, arg, robot_, 1e-8);
 }
 }  // namespace constraints


### PR DESCRIPTION
  The function used to compute the log of Yoshikawa's manipulability index
  and to return the max between 0 and the opposite of the latter log.
  Simply said, the function used to tend to infinity when the manipulability
  index converged toward 0, and to be uniformly equal to 0 when the
  manipulability index was was greater than 1. Minimizing the norm of this
  function moves the configuration to the latter domain. This function has
  been renamed MinManipulability since it enforces (by minimization) a minimal
  manipulability index.

  Function Manipulability now returns the log of the manipulability index.